### PR TITLE
Fix sync failure when AppsJsonPath setting is empty (#11)

### DIFF
--- a/ApolloSync.cs
+++ b/ApolloSync.cs
@@ -1265,10 +1265,15 @@ namespace ApolloSync
             try
             {
                 var path = _settings.Settings.AppsJsonPath;
-                logger.Debug($"Saving apps config to path: {path}");
+                // Resolve to the concrete path ConfigService.Save will write to, so the
+                // elevation path below receives a valid local absolute path even when
+                // the user hasn't configured a custom AppsJsonPath. Match Save's
+                // preferExisting: true so elevation and Save target the same file.
+                var resolvedPath = Services.ConfigService.ResolveConfigPath(path, preferExisting: true);
+                logger.Debug($"Saving apps config to path: {resolvedPath}");
                 try
                 {
-                    configService.Save(path, config);
+                    configService.Save(resolvedPath, config);
                 }
                 catch (UnauthorizedAccessException)
                 {
@@ -1282,14 +1287,14 @@ namespace ApolloSync
                         var result = PlayniteApi.Dialogs.ShowMessage(message, title, MessageBoxButton.YesNo, MessageBoxImage.Warning);
                         if (result == MessageBoxResult.Yes)
                         {
-                            TryFixFilePermissionsWithElevation(path);
+                            TryFixFilePermissionsWithElevation(resolvedPath);
                             handled = true;
                         }
                     });
                     if (handled)
                     {
                         // Retry once after permissions fix
-                        configService.Save(path, config);
+                        configService.Save(resolvedPath, config);
                     }
                     else
                     {

--- a/Services/ConfigService.cs
+++ b/Services/ConfigService.cs
@@ -24,7 +24,7 @@ namespace ApolloSync.Services
         {
             try
             {
-                var resolvedPath = string.IsNullOrWhiteSpace(path) ? ResolveDefaultPath(preferExisting: true) : path;
+                var resolvedPath = ResolveConfigPath(path, preferExisting: true);
                 logger.Debug($"ConfigService.Load - Resolved path: {resolvedPath}");
 
                 if (string.IsNullOrWhiteSpace(resolvedPath) || !File.Exists(resolvedPath))
@@ -58,7 +58,9 @@ namespace ApolloSync.Services
         {
             try
             {
-                var resolvedPath = string.IsNullOrWhiteSpace(path) ? ResolveDefaultPath(preferExisting: false) : path;
+                // preferExisting: true so a Sunshine-only install writes back to its own
+                // apps.json instead of silently creating a new Apollo config that nothing reads.
+                var resolvedPath = ResolveConfigPath(path, preferExisting: true);
                 logger.Debug($"ConfigService.Save - Resolved path: {resolvedPath}");
 
                 var dir = Path.GetDirectoryName(resolvedPath);
@@ -142,6 +144,17 @@ namespace ApolloSync.Services
                 && root.Length >= 3
                 && char.IsLetter(root[0])
                 && root[1] == ':';
+        }
+
+        /// <summary>
+        /// Resolves the apps.json path used by Load/Save. If <paramref name="path"/> is non-empty
+        /// it is returned as-is; otherwise the default Apollo/Sunshine install path is used.
+        /// Exposed so callers (e.g. the permission-fix elevation flow) can act on the same
+        /// concrete path that Load/Save will ultimately hit.
+        /// </summary>
+        public static string ResolveConfigPath(string path, bool preferExisting)
+        {
+            return string.IsNullOrWhiteSpace(path) ? ResolveDefaultPath(preferExisting) : path;
         }
 
         private static string ResolveDefaultPath(bool preferExisting)

--- a/Tests/AppsJsonManagementTests.cs
+++ b/Tests/AppsJsonManagementTests.cs
@@ -171,6 +171,106 @@ namespace ApolloSync.Tests
             Assert.IsFalse(ConfigService.IsLocalAbsolutePath("   "));
         }
 
+        // ── ResolveConfigPath ─────────────────────────────────────────────────────
+
+        [TestMethod]
+        public void ResolveConfigPath_PassesThroughCustomPath()
+        {
+            var custom = @"D:\custom\apps.json";
+            Assert.AreEqual(custom, ConfigService.ResolveConfigPath(custom, preferExisting: true));
+            Assert.AreEqual(custom, ConfigService.ResolveConfigPath(custom, preferExisting: false));
+        }
+
+        [TestMethod]
+        public void ResolveConfigPath_EmptyInputReturnsLocalAbsolutePath()
+        {
+            // Regression guard for issue #11: an empty AppsJsonPath setting must still
+            // resolve to a concrete local absolute path so the permission-fix elevation
+            // flow (which rejects non-local paths) can run.
+            foreach (var input in new[] { null, string.Empty, "   " })
+            {
+                var resolved = ConfigService.ResolveConfigPath(input, preferExisting: false);
+                Assert.IsTrue(
+                    ConfigService.IsLocalAbsolutePath(resolved),
+                    $"Expected local absolute path for input '{input ?? "<null>"}', got '{resolved}'");
+                StringAssert.EndsWith(resolved, @"Apollo\config\apps.json");
+            }
+        }
+
+        [TestMethod]
+        [DoNotParallelize]
+        public void Save_WithEmptyPath_WritesToSunshineWhenOnlySunshineInstalled()
+        {
+            // Regression guard: previously Save defaulted to preferExisting:false and would
+            // create a new Apollo config even for Sunshine-only users, making their sync
+            // silently write to a file nothing ever reads.
+            var originalProgramW6432 = Environment.GetEnvironmentVariable("ProgramW6432");
+            var fakeProgramFiles = Path.Combine(Path.GetTempPath(), "ApolloSyncTests", Guid.NewGuid().ToString("N"));
+            var sunshineConfig = Path.Combine(fakeProgramFiles, "Sunshine", "config");
+            var sunshineApps = Path.Combine(sunshineConfig, "apps.json");
+            var apolloApps = Path.Combine(fakeProgramFiles, "Apollo", "config", "apps.json");
+
+            try
+            {
+                Directory.CreateDirectory(sunshineConfig);
+                File.WriteAllText(sunshineApps, "{\"apps\":[],\"env\":{},\"version\":2}");
+                Environment.SetEnvironmentVariable("ProgramW6432", fakeProgramFiles);
+
+                var config = new JObject
+                {
+                    ["apps"] = new JArray(new JObject { ["name"] = "Probe", ["uuid"] = Guid.NewGuid().ToString().ToUpperInvariant() }),
+                    ["env"] = new JObject(),
+                    ["version"] = 2
+                };
+
+                new ConfigService().Save(null, config);
+
+                Assert.IsTrue(File.Exists(sunshineApps), "Save should have written to the existing Sunshine apps.json");
+                Assert.IsFalse(File.Exists(apolloApps), "Save must not silently create an Apollo config when only Sunshine exists");
+
+                var reloaded = JObject.Parse(File.ReadAllText(sunshineApps));
+                Assert.AreEqual("Probe", (string)((JArray)reloaded["apps"])[0]["name"]);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("ProgramW6432", originalProgramW6432);
+                // Best-effort temp cleanup: a locked file here shouldn't fail the test.
+                try { Directory.Delete(fakeProgramFiles, recursive: true); } catch { }
+            }
+        }
+
+        // Mutates ProgramW6432 at process scope — must not race with any other test
+        // that reads it (i.e. anything calling ConfigService.ResolveConfigPath with an empty path).
+        [TestMethod]
+        [DoNotParallelize]
+        public void ResolveConfigPath_PreferExisting_PicksSunshineWhenOnlySunshineInstalled()
+        {
+            var originalProgramW6432 = Environment.GetEnvironmentVariable("ProgramW6432");
+            var fakeProgramFiles = Path.Combine(Path.GetTempPath(), "ApolloSyncTests", Guid.NewGuid().ToString("N"));
+            var sunshineConfig = Path.Combine(fakeProgramFiles, "Sunshine", "config");
+            var sunshineApps = Path.Combine(sunshineConfig, "apps.json");
+
+            try
+            {
+                Directory.CreateDirectory(sunshineConfig);
+                File.WriteAllText(sunshineApps, "{}");
+                Environment.SetEnvironmentVariable("ProgramW6432", fakeProgramFiles);
+
+                var resolvedExisting = ConfigService.ResolveConfigPath(null, preferExisting: true);
+                Assert.AreEqual(sunshineApps, resolvedExisting);
+
+                // With preferExisting=false we always get the Apollo path, even if only Sunshine exists.
+                var resolvedDefault = ConfigService.ResolveConfigPath(null, preferExisting: false);
+                Assert.AreEqual(Path.Combine(fakeProgramFiles, "Apollo", "config", "apps.json"), resolvedDefault);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("ProgramW6432", originalProgramW6432);
+                // Best-effort temp cleanup: a locked file here shouldn't fail the test.
+                try { Directory.Delete(fakeProgramFiles, recursive: true); } catch { }
+            }
+        }
+
         // ── Atomic write ──────────────────────────────────────────────────────────
 
         [TestMethod]

--- a/Tests/AppsJsonManagementTests.cs
+++ b/Tests/AppsJsonManagementTests.cs
@@ -181,7 +181,9 @@ namespace ApolloSync.Tests
             Assert.AreEqual(custom, ConfigService.ResolveConfigPath(custom, preferExisting: false));
         }
 
+        // Reads ProgramW6432; serialize with the other tests that mutate it.
         [TestMethod]
+        [DoNotParallelize]
         public void ResolveConfigPath_EmptyInputReturnsLocalAbsolutePath()
         {
             // Regression guard for issue #11: an empty AppsJsonPath setting must still


### PR DESCRIPTION
## Summary
- `SaveAppsConfig` was passing the raw (often empty) `_settings.Settings.AppsJsonPath` to `TryFixFilePermissionsWithElevation`, which rejects non-local paths. The write failed, elevation was skipped, and the user saw no apps.json change.
- Now `SaveAppsConfig` resolves the path up front via a new public `ConfigService.ResolveConfigPath` and uses the resolved path for both the save call and the elevation helper.
- Also flips `ConfigService.Save` default from `preferExisting: false` to `true` so Sunshine-only users write back to their existing `apps.json` instead of silently creating a stale Apollo config.

Fixes #11 (sync failure branch; the original "Settings menu missing" symptom from the issue is unaddressed and needs more info from the reporter).