### PR TITLE
Add sync-by-tags and support for searching presets/tags

### DIFF
--- a/ApolloSync.cs
+++ b/ApolloSync.cs
@@ -456,11 +456,19 @@ namespace ApolloSync
         #region Game Filtering
         private List<Game> GetFilteredGames()
         {
-            // Use filter presets with OR logic - game matches if it matches ANY selected preset
-            if (_settings.Settings.IncludedFilterPresetIds?.Count > 0)
-            {
-                var matchingGames = new HashSet<Game>();
+            var hasFilterPresets = _settings.Settings.IncludedFilterPresetIds?.Count > 0;
+            var hasTags = _settings.Settings.IncludedTagIds?.Count > 0;
 
+            if (!hasFilterPresets && !hasTags)
+            {
+                logger.Warn("No filter presets or tags selected - no games will be filtered. Please select filter presets and/or tags in settings.");
+                return new List<Game>();
+            }
+
+            var matchingGames = new HashSet<Game>();
+
+            if (hasFilterPresets)
+            {
                 foreach (var presetId in _settings.Settings.IncludedFilterPresetIds)
                 {
                     var filterPreset = PlayniteApi.Database.FilterPresets
@@ -483,20 +491,30 @@ namespace ApolloSync
                         }
                     }
                 }
-
-                logger.Info($"Combined filter presets matched {matchingGames.Count} games");
-                return matchingGames.ToList();
             }
 
-            // No filter presets selected - return no games
-            logger.Warn("No filter presets selected - no games will be filtered. Please select filter presets in settings.");
-            return new List<Game>();
+            if (hasTags)
+            {
+                var tagIds = new HashSet<Guid>(_settings.Settings.IncludedTagIds);
+                var taggedGames = PlayniteApi.Database.Games
+                    .Where(g => g.Tags != null && g.Tags.Any(t => tagIds.Contains(t.Id)));
+                foreach (var game in taggedGames)
+                {
+                    matchingGames.Add(game);
+                }
+                logger.Debug($"Tag filter matched {matchingGames.Count} games (cumulative)");
+            }
+
+            logger.Info($"Combined filters matched {matchingGames.Count} games");
+            return matchingGames.ToList();
         }
 
         private bool GameMeetsCurrentFilters(Game game)
         {
-            // Use filter presets with OR logic - game matches if it matches ANY selected preset
-            if (_settings.Settings.IncludedFilterPresetIds?.Count > 0)
+            var hasFilterPresets = _settings.Settings.IncludedFilterPresetIds?.Count > 0;
+            var hasTags = _settings.Settings.IncludedTagIds?.Count > 0;
+
+            if (hasFilterPresets)
             {
                 foreach (var presetId in _settings.Settings.IncludedFilterPresetIds)
                 {
@@ -509,7 +527,7 @@ namespace ApolloSync
                         {
                             if (PlayniteApi.Database.GetGameMatchesFilter(game, filterPreset.Settings))
                             {
-                                return true; // Match found, return true immediately
+                                return true;
                             }
                         }
                         catch (Exception ex)
@@ -520,10 +538,16 @@ namespace ApolloSync
                 }
             }
 
-            // No filter presets selected or no matches found
+            if (hasTags)
+            {
+                var tagIds = new HashSet<Guid>(_settings.Settings.IncludedTagIds);
+                if (game.Tags != null && game.Tags.Any(t => tagIds.Contains(t.Id)))
+                {
+                    return true;
+                }
+            }
+
             return false;
-
-
         }
 
         private int RemoveFilteredOutGames(JObject config, HashSet<Guid> pinnedGameIds = null)

--- a/ApolloSync.cs
+++ b/ApolloSync.cs
@@ -454,6 +454,52 @@ namespace ApolloSync
         #endregion
 
         #region Game Filtering
+        private HashSet<Game> GetGamesMatchingFilterPresets()
+        {
+            var matchingGames = new HashSet<Game>();
+
+            foreach (var presetId in _settings.Settings.IncludedFilterPresetIds)
+            {
+                var filterPreset = PlayniteApi.Database.FilterPresets
+                    .FirstOrDefault(fp => fp.Id == presetId);
+
+                if (filterPreset?.Settings != null)
+                {
+                    try
+                    {
+                        var presetGames = PlayniteApi.Database.GetFilteredGames(filterPreset.Settings);
+                        foreach (var game in presetGames)
+                        {
+                            matchingGames.Add(game);
+                        }
+                        logger.Debug($"Filter preset '{filterPreset.Name}' matched {presetGames.Count()} games");
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.Error(ex, $"Failed to apply filter preset: {filterPreset.Name}");
+                    }
+                }
+            }
+
+            return matchingGames;
+        }
+
+        private HashSet<Game> GetGamesMatchingTags()
+        {
+            var matchingGames = new HashSet<Game>();
+            var tagIds = new HashSet<Guid>(_settings.Settings.IncludedTagIds);
+            var taggedGames = PlayniteApi.Database.Games
+                .Where(g => g.Tags != null && g.Tags.Any(t => tagIds.Contains(t.Id)));
+
+            foreach (var game in taggedGames)
+            {
+                matchingGames.Add(game);
+            }
+
+            logger.Debug($"Tag filter matched {matchingGames.Count} games");
+            return matchingGames;
+        }
+
         private List<Game> GetFilteredGames()
         {
             var hasFilterPresets = _settings.Settings.IncludedFilterPresetIds?.Count > 0;
@@ -465,48 +511,82 @@ namespace ApolloSync
                 return new List<Game>();
             }
 
-            var matchingGames = new HashSet<Game>();
+            var presetGames = hasFilterPresets ? GetGamesMatchingFilterPresets() : new HashSet<Game>();
+            var tagGames = hasTags ? GetGamesMatchingTags() : new HashSet<Game>();
+            HashSet<Game> matchingGames;
 
-            if (hasFilterPresets)
+            switch (_settings.Settings.PresetTagCombinationMode)
             {
-                foreach (var presetId in _settings.Settings.IncludedFilterPresetIds)
-                {
-                    var filterPreset = PlayniteApi.Database.FilterPresets
-                        .FirstOrDefault(fp => fp.Id == presetId);
-
-                    if (filterPreset?.Settings != null)
+                case PresetTagCombinationMode.And:
+                    if (!hasFilterPresets)
                     {
-                        try
-                        {
-                            var presetGames = PlayniteApi.Database.GetFilteredGames(filterPreset.Settings);
-                            foreach (var game in presetGames)
-                            {
-                                matchingGames.Add(game);
-                            }
-                            logger.Debug($"Filter preset '{filterPreset.Name}' matched {presetGames.Count()} games");
-                        }
-                        catch (Exception ex)
-                        {
-                            logger.Error(ex, $"Failed to apply filter preset: {filterPreset.Name}");
-                        }
+                        matchingGames = tagGames;
                     }
-                }
-            }
+                    else if (!hasTags)
+                    {
+                        matchingGames = presetGames;
+                    }
+                    else
+                    {
+                        matchingGames = new HashSet<Game>(presetGames);
+                        matchingGames.IntersectWith(tagGames);
+                    }
+                    break;
 
-            if (hasTags)
-            {
-                var tagIds = new HashSet<Guid>(_settings.Settings.IncludedTagIds);
-                var taggedGames = PlayniteApi.Database.Games
-                    .Where(g => g.Tags != null && g.Tags.Any(t => tagIds.Contains(t.Id)));
-                foreach (var game in taggedGames)
-                {
-                    matchingGames.Add(game);
-                }
-                logger.Debug($"Tag filter matched {matchingGames.Count} games (cumulative)");
+                case PresetTagCombinationMode.Not:
+                    if (!hasFilterPresets)
+                    {
+                        logger.Warn("Exclude-tags mode requires at least one filter preset - no games will be filtered.");
+                        return new List<Game>();
+                    }
+
+                    matchingGames = new HashSet<Game>(presetGames);
+                    if (hasTags)
+                    {
+                        matchingGames.ExceptWith(tagGames);
+                    }
+                    break;
+
+                default:
+                    matchingGames = new HashSet<Game>(presetGames);
+                    matchingGames.UnionWith(tagGames);
+                    break;
             }
 
             logger.Info($"Combined filters matched {matchingGames.Count} games");
             return matchingGames.ToList();
+        }
+
+        private bool GameMatchesAnyFilterPreset(Game game)
+        {
+            foreach (var presetId in _settings.Settings.IncludedFilterPresetIds)
+            {
+                var filterPreset = PlayniteApi.Database.FilterPresets
+                    .FirstOrDefault(fp => fp.Id == presetId);
+
+                if (filterPreset?.Settings != null)
+                {
+                    try
+                    {
+                        if (PlayniteApi.Database.GetGameMatchesFilter(game, filterPreset.Settings))
+                        {
+                            return true;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.Error(ex, $"Failed to check game against filter preset: {filterPreset.Name}");
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private bool GameMatchesAnyTag(Game game)
+        {
+            var tagIds = new HashSet<Guid>(_settings.Settings.IncludedTagIds);
+            return game.Tags != null && game.Tags.Any(t => tagIds.Contains(t.Id));
         }
 
         private bool GameMeetsCurrentFilters(Game game)
@@ -514,40 +594,55 @@ namespace ApolloSync
             var hasFilterPresets = _settings.Settings.IncludedFilterPresetIds?.Count > 0;
             var hasTags = _settings.Settings.IncludedTagIds?.Count > 0;
 
-            if (hasFilterPresets)
+            if (!hasFilterPresets && !hasTags)
             {
-                foreach (var presetId in _settings.Settings.IncludedFilterPresetIds)
-                {
-                    var filterPreset = PlayniteApi.Database.FilterPresets
-                        .FirstOrDefault(fp => fp.Id == presetId);
+                return false;
+            }
 
-                    if (filterPreset?.Settings != null)
+            var matchesPreset = hasFilterPresets && GameMatchesAnyFilterPreset(game);
+            var matchesTag = hasTags && GameMatchesAnyTag(game);
+
+            switch (_settings.Settings.PresetTagCombinationMode)
+            {
+                case PresetTagCombinationMode.And:
+                    if (!hasFilterPresets)
                     {
-                        try
-                        {
-                            if (PlayniteApi.Database.GetGameMatchesFilter(game, filterPreset.Settings))
-                            {
-                                return true;
-                            }
-                        }
-                        catch (Exception ex)
-                        {
-                            logger.Error(ex, $"Failed to check game against filter preset: {filterPreset.Name}");
-                        }
+                        return matchesTag;
                     }
-                }
-            }
 
-            if (hasTags)
-            {
-                var tagIds = new HashSet<Guid>(_settings.Settings.IncludedTagIds);
-                if (game.Tags != null && game.Tags.Any(t => tagIds.Contains(t.Id)))
-                {
-                    return true;
-                }
-            }
+                    if (!hasTags)
+                    {
+                        return matchesPreset;
+                    }
 
-            return false;
+                    return matchesPreset && matchesTag;
+
+                case PresetTagCombinationMode.Not:
+                    if (!hasFilterPresets)
+                    {
+                        return false;
+                    }
+
+                    if (!hasTags)
+                    {
+                        return matchesPreset;
+                    }
+
+                    return matchesPreset && !matchesTag;
+
+                default:
+                    if (hasFilterPresets && hasTags)
+                    {
+                        return matchesPreset || matchesTag;
+                    }
+
+                    if (hasFilterPresets)
+                    {
+                        return matchesPreset;
+                    }
+
+                    return matchesTag;
+            }
         }
 
         private int RemoveFilteredOutGames(JObject config, HashSet<Guid> pinnedGameIds = null)

--- a/ApolloSync.cs
+++ b/ApolloSync.cs
@@ -675,17 +675,6 @@ namespace ApolloSync
             logger.Info("Starting sync filtered games operation");
 
             var filteredGames = GetFilteredGames();
-            if (filteredGames.Count == 0)
-            {
-                ShowNotificationIfEnabled(new NotificationMessage(
-                    "apollosync-no-games",
-                    "No games match the selected filter presets. Please check your filter preset configuration.",
-                    NotificationType.Error), isUpdateOperation: true);
-                return;
-            }
-
-            logger.Info($"Found {filteredGames.Count} games matching filter presets to sync");
-
             var localSuccess = 0;
             var localFailure = 0;
             var localErrors = new List<string>();
@@ -711,55 +700,62 @@ namespace ApolloSync
                 return;
             }
 
-            logger.Info($"Starting batch sync operation with {filteredGames.Count} games");
-
-            // Phase 1: Remove games that no longer meet filters (unless pinned)
+            // Phase 1: Always remove managed games that no longer meet filters (unless pinned)
             var removedGames = RemoveFilteredOutGames(config, pinnedSnapshot);
             localRemoved = removedGames;
             logger.Info($"Removed {removedGames} games that no longer meet filters");
 
             // Phase 2: Add/update games that meet current filters
-            for (int i = 0; i < filteredGames.Count; i++)
+            if (filteredGames.Count > 0)
             {
-                if (cancellationToken.IsCancellationRequested)
-                {
-                    logger.Info("Sync cancelled by user");
-                    break;
-                }
+                logger.Info($"Found {filteredGames.Count} games matching filters to sync");
 
-                var game = filteredGames[i];
-                logger.Debug($"Processing game: {game.Name} (ID: {game.Id})");
-
-                try
+                for (int i = 0; i < filteredGames.Count; i++)
                 {
-                    // Check if this game was manually removed and should not be re-added
-                    if (IsGameManuallyRemoved(game, config))
+                    if (cancellationToken.IsCancellationRequested)
                     {
-                        logger.Info($"Skipping game {game.Name} - appears to have been manually removed from Apollo management");
-                        continue;
+                        logger.Info("Sync cancelled by user");
+                        break;
                     }
 
-                    // Use batch operation that doesn't save to disk
-                    if (TryAddOrUpdateAppBatch(game, config))
+                    var game = filteredGames[i];
+                    logger.Debug($"Processing game: {game.Name} (ID: {game.Id})");
+
+                    try
                     {
-                        localSuccess++;
-                        logger.Debug($"Successfully processed: {game.Name}");
+                        // Check if this game was manually removed and should not be re-added
+                        if (IsGameManuallyRemoved(game, config))
+                        {
+                            logger.Info($"Skipping game {game.Name} - appears to have been manually removed from Apollo management");
+                            continue;
+                        }
+
+                        // Use batch operation that doesn't save to disk
+                        if (TryAddOrUpdateAppBatch(game, config))
+                        {
+                            localSuccess++;
+                            logger.Debug($"Successfully processed: {game.Name}");
+                        }
+                        else
+                        {
+                            localFailure++;
+                            var error = $"Failed to process: {game.Name}";
+                            localErrors.Add(error);
+                            logger.Warn(error);
+                        }
                     }
-                    else
+                    catch (Exception ex)
                     {
                         localFailure++;
-                        var error = $"Failed to process: {game.Name}";
+                        var error = $"Error processing {game.Name}: {ex.Message}";
                         localErrors.Add(error);
-                        logger.Warn(error);
+                        logger.Error(ex, error);
                     }
                 }
-                catch (Exception ex)
-                {
-                    localFailure++;
-                    var error = $"Error processing {game.Name}: {ex.Message}";
-                    localErrors.Add(error);
-                    logger.Error(ex, error);
-                }
+            }
+            else
+            {
+                logger.Info("No games match current filters; skipping add/update phase");
             }
 
             // Save everything once at the end

--- a/Localization/cs_CZ.xaml
+++ b/Localization/cs_CZ.xaml
@@ -57,6 +57,17 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Použít předvolbu filtru Playnite</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Pokud je povoleno, bude místo jednotlivých filtrů níže použita vybraná předvolba filtru. Předvolby filtrů vytvořte v hlavním zobrazení knihovny Playnite.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help">Vyberte jednu nebo více předvoleb filtrů a/nebo tagů. Hry odpovídající libovolné vybrané předvolbě nebo tagu budou způsobilé k exportu (logika NEBO). Nejdříve vytvořte předvolby filtrů v hlavním zobrazení knihovny Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_Or">Vyberte jednu nebo více předvoleb filtrů a/nebo tagů. Hry odpovídající libovolné vybrané předvolbě nebo tagu jsou způsobilé k exportu (NEBO). V každém seznamu platí jakákoli zaškrtnutá položka.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_And">Vyberte předvolby filtrů nahoře a tagy dole. Hry musí odpovídat alespoň jedné zaškrtnuté předvolbě a alespoň jednomu zaškrtnutému tagu (A). Pokud má výběr pouze jeden seznam, rozhoduje jen ten.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_Not">Hry musí odpovídat vybrané předvolbě filtru, ale nesmí mít žádný vybraný tag — užitečné pro export shod s předvolbou bez otagovaných her. Je vyžadována alespoň jedna předvolba filtru; tagy jsou volitelná vyloučení.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_CreatePresets">Nejdříve vytvořte předvolby filtrů v hlavním zobrazení knihovny Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination">Kombinovat předvolby a tagy:</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Or">Libovolné (NEBO)</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_And">Obojí (A)</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Not">Vyloučit tagy</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Or_Tooltip">Exportovat hry odpovídající libovolné vybrané předvolbě filtru nebo tagu.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_And_Tooltip">Exportovat hry odpovídající alespoň jedné vybrané předvolbě a alespoň jednomu vybranému tagu.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Not_Tooltip">Exportovat hry odpovídající předvolbě, ale bez vybraných tagů.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterSearch_Tooltip">Filtrujte seznamy podle názvu. Zaškrtnuté položky zůstanou vybrané, i když jsou skryté.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly">Zobrazit pouze zaškrtnuté</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly_Tooltip">Zobrazit pouze předvolby a tagy, které jsou aktuálně zaškrtnuté.</sys:String>

--- a/Localization/cs_CZ.xaml
+++ b/Localization/cs_CZ.xaml
@@ -56,6 +56,14 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Předvolba filtru</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Použít předvolbu filtru Playnite</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Pokud je povoleno, bude místo jednotlivých filtrů níže použita vybraná předvolba filtru. Předvolby filtrů vytvořte v hlavním zobrazení knihovny Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help">Vyberte jednu nebo více předvoleb filtrů a/nebo tagů. Hry odpovídající libovolné vybrané předvolbě nebo tagu budou způsobilé k exportu (logika NEBO). Nejdříve vytvořte předvolby filtrů v hlavním zobrazení knihovny Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterSearch_Tooltip">Filtrujte seznamy podle názvu. Zaškrtnuté položky zůstanou vybrané, i když jsou skryté.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly">Zobrazit pouze zaškrtnuté</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly_Tooltip">Zobrazit pouze předvolby a tagy, které jsou aktuálně zaškrtnuté.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterPresets">Předvolby filtrů</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterPresets_Selected">Předvolby filtrů ({0} vybráno)</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_TagPresets">Předvolby tagů</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_TagPresets_Selected">Předvolby tagů ({0} vybráno)</sys:String>
 
     <!-- Manage Games Tab -->
     <sys:String x:Key="LOC_ApolloSync_Settings_ManageGames">Spravovat exportované hry</sys:String>

--- a/Localization/de_DE.xaml
+++ b/Localization/de_DE.xaml
@@ -56,6 +56,14 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Filtervoreinstellung</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Playnite-Filtervoreinstellung verwenden</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Wenn aktiviert, wird die ausgewählte Filtervoreinstellung anstelle der einzelnen Filter unten verwendet. Erstellen Sie Filtervoreinstellungen in der Hauptbibliotheksansicht von Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help">Wähle ein oder mehrere Filtervoreinstellungen und/oder Tags. Spiele, die einer ausgewählten Voreinstellung oder einem Tag entsprechen, sind für den Export geeignet (ODER-Logik). Erstelle Filtervoreinstellungen zuerst in der Hauptbibliotheksansicht von Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterSearch_Tooltip">Filtere die Listen nach Name. Ausgewählte Einträge bleiben ausgewählt, wenn sie ausgeblendet werden.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly">Nur Ausgewählte anzeigen</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly_Tooltip">Nur Voreinstellungen und Tags anzeigen, die derzeit ausgewählt sind.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterPresets">Filtervoreinstellungen</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterPresets_Selected">Filtervoreinstellungen ({0} ausgewählt)</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_TagPresets">Tag-Voreinstellungen</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_TagPresets_Selected">Tag-Voreinstellungen ({0} ausgewählt)</sys:String>
 
     <!-- Manage Games Tab -->
     <sys:String x:Key="LOC_ApolloSync_Settings_ManageGames">Exportierte Spiele verwalten</sys:String>

--- a/Localization/de_DE.xaml
+++ b/Localization/de_DE.xaml
@@ -57,6 +57,17 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Playnite-Filtervoreinstellung verwenden</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Wenn aktiviert, wird die ausgewählte Filtervoreinstellung anstelle der einzelnen Filter unten verwendet. Erstellen Sie Filtervoreinstellungen in der Hauptbibliotheksansicht von Playnite.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help">Wähle ein oder mehrere Filtervoreinstellungen und/oder Tags. Spiele, die einer ausgewählten Voreinstellung oder einem Tag entsprechen, sind für den Export geeignet (ODER-Logik). Erstelle Filtervoreinstellungen zuerst in der Hauptbibliotheksansicht von Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_Or">Wähle eine oder mehrere Filtervoreinstellungen und/oder Tags. Spiele, die einer ausgewählten Voreinstellung oder einem Tag entsprechen, sind exportierbar (ODER). Innerhalb jeder Liste gilt jedes aktivierte Element.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_And">Wähle Filtervoreinstellungen oben und Tags unten. Spiele müssen mindestens einer Voreinstellung und mindestens einem Tag entsprechen (UND). Hat nur eine Liste Auswahlen, gilt allein diese Liste.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_Not">Spiele müssen einer Filtervoreinstellung entsprechen, aber keinem ausgewählten Tag haben — nützlich, um Voreinstellungs-Treffer ohne getaggte Spiele zu exportieren. Mindestens eine Filtervoreinstellung ist erforderlich; Tags sind optionale Ausschlüsse.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_CreatePresets">Erstelle Filtervoreinstellungen zuerst in der Hauptbibliotheksansicht von Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination">Voreinstellungen und Tags kombinieren:</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Or">Beliebig (ODER)</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_And">Beide (UND)</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Not">Tags ausschließen</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Or_Tooltip">Spiele exportieren, die einer ausgewählten Filtervoreinstellung oder einem ausgewählten Tag entsprechen.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_And_Tooltip">Spiele exportieren, die mindestens einer Voreinstellung und mindestens einem Tag entsprechen.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Not_Tooltip">Spiele exportieren, die einer Voreinstellung entsprechen, aber keinen ausgewählten Tag haben.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterSearch_Tooltip">Filtere die Listen nach Name. Ausgewählte Einträge bleiben ausgewählt, wenn sie ausgeblendet werden.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly">Nur Ausgewählte anzeigen</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly_Tooltip">Nur Voreinstellungen und Tags anzeigen, die derzeit ausgewählt sind.</sys:String>

--- a/Localization/en_US.xaml
+++ b/Localization/en_US.xaml
@@ -56,6 +56,14 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Filter Preset</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Use Playnite Filter Preset</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">When enabled, the selected filter preset will be used instead of the individual filters below. Create filter presets in Playnite's main library view.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help">Select one or more filter presets and/or tags to filter by. Games that match ANY selected preset or tag will be eligible for export (OR logic). Create filter presets in Playnite's main library view first.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterSearch_Tooltip">Filter the preset and tag lists by name. Checked items stay selected when filtered out.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly">Show checked only</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly_Tooltip">Show only presets and tags that are currently checked.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterPresets">Filter Presets</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterPresets_Selected">Filter Presets ({0} selected)</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_TagPresets">Tag Presets</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_TagPresets_Selected">Tag Presets ({0} selected)</sys:String>
 
     <!-- Manage Games Tab -->
     <sys:String x:Key="LOC_ApolloSync_Settings_ManageGames">Manage Exported Games</sys:String>

--- a/Localization/en_US.xaml
+++ b/Localization/en_US.xaml
@@ -57,6 +57,17 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Use Playnite Filter Preset</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">When enabled, the selected filter preset will be used instead of the individual filters below. Create filter presets in Playnite's main library view.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help">Select one or more filter presets and/or tags to filter by. Games that match ANY selected preset or tag will be eligible for export (OR logic). Create filter presets in Playnite's main library view first.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_Or">Select one or more filter presets and/or tags. Games matching any selected preset or tag are eligible for export (OR). Within each list, any checked item matches.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_And">Select filter presets above and tags below. Games must match at least one checked preset and at least one checked tag (AND). If only one list has selections, that list alone determines eligibility.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_Not">Games must match a selected filter preset but must not have any selected tag — useful for exporting preset matches while excluding tagged games. At least one filter preset is required; tags are optional exclusions.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_CreatePresets">Create filter presets in Playnite's main library view first.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination">Combine presets and tags:</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Or">Any (OR)</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_And">Both (AND)</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Not">Exclude tags</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Or_Tooltip">Export games that match any selected filter preset or any selected tag.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_And_Tooltip">Export games that match at least one selected preset and at least one selected tag.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Not_Tooltip">Export games that match a selected preset but do not have any selected tag.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterSearch_Tooltip">Filter the preset and tag lists by name. Checked items stay selected when filtered out.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly">Show checked only</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly_Tooltip">Show only presets and tags that are currently checked.</sys:String>

--- a/Localization/es_ES.xaml
+++ b/Localization/es_ES.xaml
@@ -56,6 +56,14 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Preajuste de filtro</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Usar preajuste de filtro de Playnite</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Cuando está activado, se usará el preajuste de filtro seleccionado en lugar de los filtros individuales de abajo. Crea preajustes de filtro en la vista principal de la biblioteca de Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help">Selecciona uno o más preajustes de filtro y/o etiquetas. Los juegos que coincidan con cualquier preajuste o etiqueta seleccionados serán elegibles para exportar (lógica OR). Crea preajustes de filtro primero en la vista principal de la biblioteca de Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterSearch_Tooltip">Filtra las listas por nombre. Los elementos marcados permanecen seleccionados cuando se ocultan.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly">Mostrar solo marcados</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly_Tooltip">Mostrar solo preajustes y etiquetas que estén marcados actualmente.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterPresets">Preajustes de filtro</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterPresets_Selected">Preajustes de filtro ({0} seleccionados)</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_TagPresets">Preajustes de etiquetas</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_TagPresets_Selected">Preajustes de etiquetas ({0} seleccionados)</sys:String>
 
     <!-- Manage Games Tab -->
     <sys:String x:Key="LOC_ApolloSync_Settings_ManageGames">Administrar juegos exportados</sys:String>

--- a/Localization/es_ES.xaml
+++ b/Localization/es_ES.xaml
@@ -57,6 +57,17 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Usar preajuste de filtro de Playnite</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Cuando está activado, se usará el preajuste de filtro seleccionado en lugar de los filtros individuales de abajo. Crea preajustes de filtro en la vista principal de la biblioteca de Playnite.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help">Selecciona uno o más preajustes de filtro y/o etiquetas. Los juegos que coincidan con cualquier preajuste o etiqueta seleccionados serán elegibles para exportar (lógica OR). Crea preajustes de filtro primero en la vista principal de la biblioteca de Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_Or">Selecciona uno o más preajustes de filtro y/o etiquetas. Los juegos que coincidan con cualquier preajuste o etiqueta seleccionados son elegibles para exportar (OR). En cada lista, cualquier elemento marcado cuenta.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_And">Selecciona preajustes de filtro arriba y etiquetas abajo. Los juegos deben coincidir con al menos un preajuste marcado y al menos una etiqueta marcada (AND). Si solo una lista tiene selecciones, esa lista sola determina la elegibilidad.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_Not">Los juegos deben coincidir con un preajuste de filtro pero no tener ninguna etiqueta seleccionada — útil para exportar coincidencias de preajuste excluyendo juegos etiquetados. Se requiere al menos un preajuste de filtro; las etiquetas son exclusiones opcionales.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_CreatePresets">Crea preajustes de filtro primero en la vista principal de la biblioteca de Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination">Combinar preajustes y etiquetas:</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Or">Cualquiera (OR)</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_And">Ambos (AND)</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Not">Excluir etiquetas</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Or_Tooltip">Exportar juegos que coincidan con cualquier preajuste de filtro o etiqueta seleccionados.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_And_Tooltip">Exportar juegos que coincidan con al menos un preajuste y al menos una etiqueta seleccionados.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Not_Tooltip">Exportar juegos que coincidan con un preajuste pero no tengan ninguna etiqueta seleccionada.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterSearch_Tooltip">Filtra las listas por nombre. Los elementos marcados permanecen seleccionados cuando se ocultan.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly">Mostrar solo marcados</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly_Tooltip">Mostrar solo preajustes y etiquetas que estén marcados actualmente.</sys:String>

--- a/Localization/fr_FR.xaml
+++ b/Localization/fr_FR.xaml
@@ -56,6 +56,14 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Préréglage de filtre</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Utiliser un préréglage de filtre Playnite</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Lorsque activé, le préréglage de filtre sélectionné sera utilisé à la place des filtres individuels ci-dessous. Créez des préréglages de filtre dans la vue principale de la bibliothèque Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help">Sélectionnez une ou plusieurs présélections de filtres et/ou tags. Les jeux correspondant à une présélection ou un tag sélectionné seront éligibles à l'export (logique OU). Créez d'abord des présélections de filtres dans la vue principale de la bibliothèque Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterSearch_Tooltip">Filtrez les listes par nom. Les éléments cochés restent sélectionnés lorsqu'ils sont masqués.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly">Afficher uniquement les cochés</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly_Tooltip">Afficher uniquement les présélections et tags actuellement cochés.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterPresets">Présélections de filtres</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterPresets_Selected">Présélections de filtres ({0} sélectionnées)</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_TagPresets">Présélections de tags</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_TagPresets_Selected">Présélections de tags ({0} sélectionnées)</sys:String>
 
     <!-- Manage Games Tab -->
     <sys:String x:Key="LOC_ApolloSync_Settings_ManageGames">Gérer les jeux exportés</sys:String>

--- a/Localization/fr_FR.xaml
+++ b/Localization/fr_FR.xaml
@@ -57,6 +57,17 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Utiliser un préréglage de filtre Playnite</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Lorsque activé, le préréglage de filtre sélectionné sera utilisé à la place des filtres individuels ci-dessous. Créez des préréglages de filtre dans la vue principale de la bibliothèque Playnite.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help">Sélectionnez une ou plusieurs présélections de filtres et/ou tags. Les jeux correspondant à une présélection ou un tag sélectionné seront éligibles à l'export (logique OU). Créez d'abord des présélections de filtres dans la vue principale de la bibliothèque Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_Or">Sélectionnez une ou plusieurs présélections de filtres et/ou tags. Les jeux correspondant à une présélection ou un tag sélectionné sont éligibles à l'export (OU). Dans chaque liste, tout élément coché correspond.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_And">Sélectionnez des présélections de filtres ci-dessus et des tags ci-dessous. Les jeux doivent correspondre à au moins une présélection cochée et à au moins un tag coché (ET). Si une seule liste a des sélections, seule cette liste détermine l'éligibilité.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_Not">Les jeux doivent correspondre à une présélection de filtre mais ne doivent avoir aucun tag sélectionné — utile pour exporter les correspondances de présélection en excluant les jeux tagués. Au moins une présélection de filtre est requise ; les tags sont des exclusions optionnelles.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_CreatePresets">Créez d'abord des présélections de filtres dans la vue principale de la bibliothèque Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination">Combiner présélections et tags :</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Or">N'importe lequel (OU)</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_And">Les deux (ET)</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Not">Exclure les tags</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Or_Tooltip">Exporter les jeux correspondant à une présélection de filtre ou à un tag sélectionné.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_And_Tooltip">Exporter les jeux correspondant à au moins une présélection et à au moins un tag sélectionnés.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Not_Tooltip">Exporter les jeux correspondant à une présélection mais n'ayant aucun tag sélectionné.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterSearch_Tooltip">Filtrez les listes par nom. Les éléments cochés restent sélectionnés lorsqu'ils sont masqués.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly">Afficher uniquement les cochés</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly_Tooltip">Afficher uniquement les présélections et tags actuellement cochés.</sys:String>

--- a/Localization/it_IT.xaml
+++ b/Localization/it_IT.xaml
@@ -56,6 +56,14 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Preset filtro</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Usa preset filtro di Playnite</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Quando attivato, verrà utilizzato il preset filtro selezionato al posto dei filtri individuali sottostanti. Crea i preset filtro nella vista principale della libreria di Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help">Seleziona uno o più preset filtro e/o tag. I giochi che corrispondono a qualsiasi preset o tag selezionato saranno idonei all'esportazione (logica OR). Crea prima i preset filtro nella vista principale della libreria di Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterSearch_Tooltip">Filtra gli elenchi per nome. Gli elementi selezionati restano selezionati quando nascosti.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly">Mostra solo selezionati</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly_Tooltip">Mostra solo preset e tag attualmente selezionati.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterPresets">Preset filtro</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterPresets_Selected">Preset filtro ({0} selezionati)</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_TagPresets">Preset tag</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_TagPresets_Selected">Preset tag ({0} selezionati)</sys:String>
 
     <!-- Manage Games Tab -->
     <sys:String x:Key="LOC_ApolloSync_Settings_ManageGames">Gestisci giochi esportati</sys:String>

--- a/Localization/it_IT.xaml
+++ b/Localization/it_IT.xaml
@@ -57,6 +57,17 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Usa preset filtro di Playnite</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Quando attivato, verrà utilizzato il preset filtro selezionato al posto dei filtri individuali sottostanti. Crea i preset filtro nella vista principale della libreria di Playnite.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help">Seleziona uno o più preset filtro e/o tag. I giochi che corrispondono a qualsiasi preset o tag selezionato saranno idonei all'esportazione (logica OR). Crea prima i preset filtro nella vista principale della libreria di Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_Or">Seleziona uno o più preset filtro e/o tag. I giochi che corrispondono a qualsiasi preset o tag selezionato sono idonei all'esportazione (OR). In ogni elenco, corrisponde qualsiasi elemento selezionato.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_And">Seleziona i preset filtro sopra e i tag sotto. I giochi devono corrispondere ad almeno un preset selezionato e ad almeno un tag selezionato (AND). Se solo un elenco ha selezioni, decide solo quell'elenco.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_Not">I giochi devono corrispondere a un preset filtro selezionato ma non devono avere alcun tag selezionato — utile per esportare le corrispondenze del preset escludendo i giochi taggati. È richiesto almeno un preset filtro; i tag sono esclusioni opzionali.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_CreatePresets">Crea prima i preset filtro nella vista principale della libreria di Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination">Combina preset e tag:</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Or">Qualsiasi (OR)</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_And">Entrambi (AND)</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Not">Escludi tag</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Or_Tooltip">Esporta i giochi che corrispondono a qualsiasi preset filtro o tag selezionato.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_And_Tooltip">Esporta i giochi che corrispondono ad almeno un preset e ad almeno un tag selezionati.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Not_Tooltip">Esporta i giochi che corrispondono a un preset ma non hanno alcun tag selezionato.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterSearch_Tooltip">Filtra gli elenchi per nome. Gli elementi selezionati restano selezionati quando nascosti.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly">Mostra solo selezionati</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly_Tooltip">Mostra solo preset e tag attualmente selezionati.</sys:String>

--- a/Localization/ja_JP.xaml
+++ b/Localization/ja_JP.xaml
@@ -57,6 +57,17 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Playniteのフィルタープリセットを使用</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">有効にすると、以下の個別フィルターの代わりに選択したフィルタープリセットが使用されます。フィルタープリセットはPlayniteのメインライブラリ画面で作成できます。</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help">フィルタープリセットおよび/またはタグを1つ以上選択してください。選択したプリセットまたはタグのいずれかに一致するゲームがエクスポート対象になります（OR条件）。フィルタープリセットはPlayniteのメインライブラリ画面で先に作成してください。</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_Or">フィルタープリセットおよび/またはタグを1つ以上選択してください。選択したプリセットまたはタグのいずれかに一致するゲームがエクスポート対象になります（OR）。各リスト内では、チェックした項目のいずれかに一致します。</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_And">上でフィルタープリセット、下でタグを選択してください。ゲームはチェックしたプリセットとチェックしたタグの両方に、それぞれ少なくとも1つ一致する必要があります（AND）。片方のリストだけに選択がある場合は、そのリストのみで判定します。</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_Not">ゲームは選択したフィルタープリセットに一致し、選択したタグを持っていてはいけません。プリセット一致からタグ付きゲームを除外してエクスポートする場合に便利です。フィルタープリセットを1つ以上選択する必要があり、タグは任意の除外条件です。</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_CreatePresets">フィルタープリセットはPlayniteのメインライブラリ画面で先に作成してください。</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination">プリセットとタグの組み合わせ:</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Or">いずれか（OR）</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_And">両方（AND）</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Not">タグを除外</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Or_Tooltip">選択したフィルタープリセットまたはタグのいずれかに一致するゲームをエクスポートします。</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_And_Tooltip">選択したプリセットとタグの両方に、それぞれ少なくとも1つ一致するゲームをエクスポートします。</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Not_Tooltip">プリセットに一致するが、選択したタグを持たないゲームをエクスポートします。</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterSearch_Tooltip">名前でプリセットとタグの一覧を絞り込みます。非表示になってもチェック状態は維持されます。</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly">チェック済みのみ表示</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly_Tooltip">現在チェックされているプリセットとタグのみを表示します。</sys:String>

--- a/Localization/ja_JP.xaml
+++ b/Localization/ja_JP.xaml
@@ -56,6 +56,14 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">フィルタープリセット</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Playniteのフィルタープリセットを使用</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">有効にすると、以下の個別フィルターの代わりに選択したフィルタープリセットが使用されます。フィルタープリセットはPlayniteのメインライブラリ画面で作成できます。</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help">フィルタープリセットおよび/またはタグを1つ以上選択してください。選択したプリセットまたはタグのいずれかに一致するゲームがエクスポート対象になります（OR条件）。フィルタープリセットはPlayniteのメインライブラリ画面で先に作成してください。</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterSearch_Tooltip">名前でプリセットとタグの一覧を絞り込みます。非表示になってもチェック状態は維持されます。</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly">チェック済みのみ表示</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly_Tooltip">現在チェックされているプリセットとタグのみを表示します。</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterPresets">フィルタープリセット</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterPresets_Selected">フィルタープリセット（{0} 件選択）</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_TagPresets">タグプリセット</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_TagPresets_Selected">タグプリセット（{0} 件選択）</sys:String>
 
     <!-- Manage Games Tab -->
     <sys:String x:Key="LOC_ApolloSync_Settings_ManageGames">エクスポート済みゲームの管理</sys:String>

--- a/Localization/ko_KR.xaml
+++ b/Localization/ko_KR.xaml
@@ -57,6 +57,17 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Playnite 필터 프리셋 사용</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">활성화하면 아래의 개별 필터 대신 선택한 필터 프리셋이 사용됩니다. 필터 프리셋은 Playnite의 메인 라이브러리 화면에서 만들 수 있습니다.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help">하나 이상의 필터 프리셋 및/또는 태그를 선택하세요. 선택한 프리셋 또는 태그 중 하나와 일치하는 게임이 내보내기 대상이 됩니다(OR 논리). 필터 프리셋은 Playnite 메인 라이브러리 화면에서 먼저 만드세요.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_Or">하나 이상의 필터 프리셋 및/또는 태그를 선택하세요. 선택한 프리셋 또는 태그 중 하나와 일치하는 게임이 내보내기 대상이 됩니다(OR). 각 목록에서는 선택한 항목 중 하나와 일치하면 됩니다.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_And">위에서 필터 프리셋, 아래에서 태그를 선택하세요. 게임은 선택한 프리셋과 태그 각각에 최소 하나씩 일치해야 합니다(AND). 한쪽 목록만 선택되어 있으면 해당 목록만으로 판단합니다.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_Not">게임은 선택한 필터 프리셋과 일치해야 하며 선택한 태그를 가져서는 안 됩니다. 프리셋 일치에서 태그가 있는 게임을 제외해 내보낼 때 유용합니다. 필터 프리셋을 하나 이상 선택해야 하며, 태그는 선택적 제외 조건입니다.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_CreatePresets">필터 프리셋은 Playnite 메인 라이브러리 화면에서 먼저 만드세요.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination">프리셋과 태그 조합:</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Or">하나라도(OR)</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_And">둘 다(AND)</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Not">태그 제외</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Or_Tooltip">선택한 필터 프리셋 또는 태그 중 하나와 일치하는 게임을 내보냅니다.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_And_Tooltip">선택한 프리셋과 태그 각각에 최소 하나씩 일치하는 게임을 내보냅니다.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Not_Tooltip">프리셋과 일치하지만 선택한 태그가 없는 게임을 내보냅니다.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterSearch_Tooltip">이름으로 프리셋 및 태그 목록을 필터링합니다. 숨겨져도 체크된 항목은 선택 상태를 유지합니다.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly">체크된 항목만 표시</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly_Tooltip">현재 체크된 프리셋과 태그만 표시합니다.</sys:String>

--- a/Localization/ko_KR.xaml
+++ b/Localization/ko_KR.xaml
@@ -56,6 +56,14 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">필터 프리셋</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Playnite 필터 프리셋 사용</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">활성화하면 아래의 개별 필터 대신 선택한 필터 프리셋이 사용됩니다. 필터 프리셋은 Playnite의 메인 라이브러리 화면에서 만들 수 있습니다.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help">하나 이상의 필터 프리셋 및/또는 태그를 선택하세요. 선택한 프리셋 또는 태그 중 하나와 일치하는 게임이 내보내기 대상이 됩니다(OR 논리). 필터 프리셋은 Playnite 메인 라이브러리 화면에서 먼저 만드세요.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterSearch_Tooltip">이름으로 프리셋 및 태그 목록을 필터링합니다. 숨겨져도 체크된 항목은 선택 상태를 유지합니다.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly">체크된 항목만 표시</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly_Tooltip">현재 체크된 프리셋과 태그만 표시합니다.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterPresets">필터 프리셋</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterPresets_Selected">필터 프리셋 ({0}개 선택됨)</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_TagPresets">태그 프리셋</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_TagPresets_Selected">태그 프리셋 ({0}개 선택됨)</sys:String>
 
     <!-- Manage Games Tab -->
     <sys:String x:Key="LOC_ApolloSync_Settings_ManageGames">내보낸 게임 관리</sys:String>

--- a/Localization/nl_NL.xaml
+++ b/Localization/nl_NL.xaml
@@ -56,6 +56,14 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Filtervoorinstelling</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Playnite-filtervoorinstelling gebruiken</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Wanneer ingeschakeld, wordt de geselecteerde filtervoorinstelling gebruikt in plaats van de afzonderlijke filters hieronder. Maak filtervoorinstellingen aan in de hoofdbibliotheekweergave van Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help">Selecteer een of meer filtervoorinstellingen en/of tags. Games die overeenkomen met een geselecteerde voorinstelling of tag komen in aanmerking voor export (OF-logica). Maak filtervoorinstellingen eerst aan in de hoofdbibliotheekweergave van Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterSearch_Tooltip">Filter de lijsten op naam. Aangevinkte items blijven geselecteerd wanneer ze verborgen zijn.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly">Alleen aangevinkte tonen</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly_Tooltip">Toon alleen voorinstellingen en tags die momenteel zijn aangevinkt.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterPresets">Filtervoorinstellingen</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterPresets_Selected">Filtervoorinstellingen ({0} geselecteerd)</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_TagPresets">Tagvoorinstellingen</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_TagPresets_Selected">Tagvoorinstellingen ({0} geselecteerd)</sys:String>
 
     <!-- Manage Games Tab -->
     <sys:String x:Key="LOC_ApolloSync_Settings_ManageGames">Geëxporteerde games beheren</sys:String>

--- a/Localization/nl_NL.xaml
+++ b/Localization/nl_NL.xaml
@@ -57,6 +57,17 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Playnite-filtervoorinstelling gebruiken</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Wanneer ingeschakeld, wordt de geselecteerde filtervoorinstelling gebruikt in plaats van de afzonderlijke filters hieronder. Maak filtervoorinstellingen aan in de hoofdbibliotheekweergave van Playnite.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help">Selecteer een of meer filtervoorinstellingen en/of tags. Games die overeenkomen met een geselecteerde voorinstelling of tag komen in aanmerking voor export (OF-logica). Maak filtervoorinstellingen eerst aan in de hoofdbibliotheekweergave van Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_Or">Selecteer een of meer filtervoorinstellingen en/of tags. Games die overeenkomen met een geselecteerde voorinstelling of tag komen in aanmerking voor export (OF). Binnen elke lijst geldt elk aangevinkt item.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_And">Selecteer filtervoorinstellingen hierboven en tags hieronder. Games moeten overeenkomen met minstens één aangevinkte voorinstelling en minstens één aangevinkte tag (EN). Als slechts één lijst selecties heeft, bepaalt alleen die lijst de geschiktheid.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_Not">Games moeten overeenkomen met een geselecteerde filtervoorinstelling maar mogen geen geselecteerde tag hebben — handig om voorinstellingsmatches te exporteren zonder getagde games. Minstens één filtervoorinstelling is vereist; tags zijn optionele uitsluitingen.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_CreatePresets">Maak filtervoorinstellingen eerst aan in de hoofdbibliotheekweergave van Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination">Voorinstellingen en tags combineren:</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Or">Elke (OF)</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_And">Beide (EN)</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Not">Tags uitsluiten</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Or_Tooltip">Exporteer games die overeenkomen met een geselecteerde filtervoorinstelling of tag.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_And_Tooltip">Exporteer games die overeenkomen met minstens één geselecteerde voorinstelling en minstens één geselecteerde tag.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Not_Tooltip">Exporteer games die overeenkomen met een voorinstelling maar geen geselecteerde tag hebben.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterSearch_Tooltip">Filter de lijsten op naam. Aangevinkte items blijven geselecteerd wanneer ze verborgen zijn.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly">Alleen aangevinkte tonen</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly_Tooltip">Toon alleen voorinstellingen en tags die momenteel zijn aangevinkt.</sys:String>

--- a/Localization/pl_PL.xaml
+++ b/Localization/pl_PL.xaml
@@ -56,6 +56,14 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Szablon filtrów</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Użyj szablonu filtrów Playnite</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Po włączeniu wybrany szablon filtrów zostanie użyty zamiast poszczególnych filtrów poniżej. Twórz szablony filtrów w głównym widoku biblioteki Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help">Wybierz jeden lub więcej szablonów filtrów i/lub tagów. Gry pasujące do dowolnego wybranego szablonu lub tagu będą kwalifikować się do eksportu (logika LUB). Najpierw utwórz szablony filtrów w głównym widoku biblioteki Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterSearch_Tooltip">Filtruj listy według nazwy. Zaznaczone pozycje pozostają wybrane, gdy są ukryte.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly">Pokaż tylko zaznaczone</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly_Tooltip">Pokaż tylko szablony i tagi, które są obecnie zaznaczone.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterPresets">Szablony filtrów</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterPresets_Selected">Szablony filtrów ({0} zaznaczonych)</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_TagPresets">Szablony tagów</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_TagPresets_Selected">Szablony tagów ({0} zaznaczonych)</sys:String>
 
     <!-- Manage Games Tab -->
     <sys:String x:Key="LOC_ApolloSync_Settings_ManageGames">Zarządzaj wyeksportowanymi grami</sys:String>

--- a/Localization/pl_PL.xaml
+++ b/Localization/pl_PL.xaml
@@ -57,6 +57,17 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Użyj szablonu filtrów Playnite</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Po włączeniu wybrany szablon filtrów zostanie użyty zamiast poszczególnych filtrów poniżej. Twórz szablony filtrów w głównym widoku biblioteki Playnite.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help">Wybierz jeden lub więcej szablonów filtrów i/lub tagów. Gry pasujące do dowolnego wybranego szablonu lub tagu będą kwalifikować się do eksportu (logika LUB). Najpierw utwórz szablony filtrów w głównym widoku biblioteki Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_Or">Wybierz jeden lub więcej szablonów filtrów i/lub tagów. Gry pasujące do dowolnego wybranego szablonu lub tagu kwalifikują się do eksportu (LUB). W każdej liście pasuje każdy zaznaczony element.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_And">Wybierz szablony filtrów powyżej i tagi poniżej. Gry muszą pasować do co najmniej jednego zaznaczonego szablonu i co najmniej jednego zaznaczonego tagu (ORAZ). Jeśli tylko jedna lista ma zaznaczenia, decyduje wyłącznie ta lista.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_Not">Gry muszą pasować do wybranego szablonu filtra, ale nie mogą mieć żadnego wybranego tagu — przydatne do eksportu dopasowań szablonu z wykluczeniem otagowanych gier. Wymagany jest co najmniej jeden szablon filtra; tagi są opcjonalnymi wykluczeniami.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_CreatePresets">Najpierw utwórz szablony filtrów w głównym widoku biblioteki Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination">Połącz szablony i tagi:</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Or">Dowolny (LUB)</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_And">Oba (ORAZ)</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Not">Wyklucz tagi</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Or_Tooltip">Eksportuj gry pasujące do dowolnego wybranego szablonu filtra lub tagu.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_And_Tooltip">Eksportuj gry pasujące do co najmniej jednego wybranego szablonu i co najmniej jednego wybranego tagu.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Not_Tooltip">Eksportuj gry pasujące do szablonu, ale bez żadnego wybranego tagu.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterSearch_Tooltip">Filtruj listy według nazwy. Zaznaczone pozycje pozostają wybrane, gdy są ukryte.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly">Pokaż tylko zaznaczone</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly_Tooltip">Pokaż tylko szablony i tagi, które są obecnie zaznaczone.</sys:String>

--- a/Localization/pt_BR.xaml
+++ b/Localization/pt_BR.xaml
@@ -57,6 +57,17 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Usar predefinição de filtro do Playnite</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Quando ativado, a predefinição de filtro selecionada será usada no lugar dos filtros individuais abaixo. Crie predefinições de filtro na visualização principal da biblioteca do Playnite.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help">Selecione uma ou mais predefinições de filtro e/ou tags. Jogos que correspondam a qualquer predefinição ou tag selecionada serão elegíveis para exportação (lógica OU). Crie predefinições de filtro primeiro na visualização principal da biblioteca do Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_Or">Selecione uma ou mais predefinições de filtro e/ou tags. Jogos que correspondam a qualquer predefinição ou tag selecionada são elegíveis para exportação (OU). Em cada lista, qualquer item marcado corresponde.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_And">Selecione predefinições de filtro acima e tags abaixo. Os jogos devem corresponder a pelo menos uma predefinição marcada e a pelo menos uma tag marcada (E). Se apenas uma lista tiver seleções, somente essa lista determina a elegibilidade.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_Not">Os jogos devem corresponder a uma predefinição de filtro, mas não podem ter nenhuma tag selecionada — útil para exportar correspondências de predefinição excluindo jogos marcados. É necessária pelo menos uma predefinição de filtro; as tags são exclusões opcionais.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_CreatePresets">Crie predefinições de filtro primeiro na visualização principal da biblioteca do Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination">Combinar predefinições e tags:</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Or">Qualquer (OU)</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_And">Ambos (E)</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Not">Excluir tags</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Or_Tooltip">Exportar jogos que correspondam a qualquer predefinição de filtro ou tag selecionada.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_And_Tooltip">Exportar jogos que correspondam a pelo menos uma predefinição e a pelo menos uma tag selecionadas.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Not_Tooltip">Exportar jogos que correspondam a uma predefinição, mas não tenham nenhuma tag selecionada.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterSearch_Tooltip">Filtre as listas por nome. Itens marcados permanecem selecionados quando ocultos.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly">Mostrar apenas marcados</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly_Tooltip">Mostrar apenas predefinições e tags que estão marcados no momento.</sys:String>

--- a/Localization/pt_BR.xaml
+++ b/Localization/pt_BR.xaml
@@ -56,6 +56,14 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Predefinição de filtro</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Usar predefinição de filtro do Playnite</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Quando ativado, a predefinição de filtro selecionada será usada no lugar dos filtros individuais abaixo. Crie predefinições de filtro na visualização principal da biblioteca do Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help">Selecione uma ou mais predefinições de filtro e/ou tags. Jogos que correspondam a qualquer predefinição ou tag selecionada serão elegíveis para exportação (lógica OU). Crie predefinições de filtro primeiro na visualização principal da biblioteca do Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterSearch_Tooltip">Filtre as listas por nome. Itens marcados permanecem selecionados quando ocultos.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly">Mostrar apenas marcados</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly_Tooltip">Mostrar apenas predefinições e tags que estão marcados no momento.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterPresets">Predefinições de filtro</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterPresets_Selected">Predefinições de filtro ({0} selecionadas)</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_TagPresets">Predefinições de tags</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_TagPresets_Selected">Predefinições de tags ({0} selecionadas)</sys:String>
 
     <!-- Manage Games Tab -->
     <sys:String x:Key="LOC_ApolloSync_Settings_ManageGames">Gerenciar jogos exportados</sys:String>

--- a/Localization/pt_PT.xaml
+++ b/Localization/pt_PT.xaml
@@ -57,6 +57,17 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Usar predefinição de filtro do Playnite</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Quando ativado, a predefinição de filtro selecionada será utilizada em vez dos filtros individuais abaixo. Crie predefinições de filtro na vista principal da biblioteca do Playnite.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help">Selecione uma ou mais predefinições de filtro e/ou etiquetas. Os jogos que correspondam a qualquer predefinição ou etiqueta selecionada serão elegíveis para exportação (lógica OU). Crie predefinições de filtro primeiro na vista principal da biblioteca do Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_Or">Selecione uma ou mais predefinições de filtro e/ou etiquetas. Os jogos que correspondam a qualquer predefinição ou etiqueta selecionada são elegíveis para exportação (OU). Em cada lista, qualquer item assinalado corresponde.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_And">Selecione predefinições de filtro acima e etiquetas abaixo. Os jogos devem corresponder a pelo menos uma predefinição assinalada e a pelo menos uma etiqueta assinalada (E). Se apenas uma lista tiver seleções, apenas essa lista determina a elegibilidade.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_Not">Os jogos devem corresponder a uma predefinição de filtro, mas não podem ter nenhuma etiqueta selecionada — útil para exportar correspondências de predefinição excluindo jogos etiquetados. É necessária pelo menos uma predefinição de filtro; as etiquetas são exclusões opcionais.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_CreatePresets">Crie predefinições de filtro primeiro na vista principal da biblioteca do Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination">Combinar predefinições e etiquetas:</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Or">Qualquer (OU)</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_And">Ambos (E)</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Not">Excluir etiquetas</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Or_Tooltip">Exportar jogos que correspondam a qualquer predefinição de filtro ou etiqueta selecionada.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_And_Tooltip">Exportar jogos que correspondam a pelo menos uma predefinição e a pelo menos uma etiqueta selecionadas.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Not_Tooltip">Exportar jogos que correspondam a uma predefinição, mas não tenham nenhuma etiqueta selecionada.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterSearch_Tooltip">Filtre as listas por nome. Os itens assinalados permanecem selecionados quando ocultos.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly">Mostrar apenas assinalados</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly_Tooltip">Mostrar apenas predefinições e etiquetas que estão assinalados de momento.</sys:String>

--- a/Localization/pt_PT.xaml
+++ b/Localization/pt_PT.xaml
@@ -56,6 +56,14 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Predefinição de filtro</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Usar predefinição de filtro do Playnite</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Quando ativado, a predefinição de filtro selecionada será utilizada em vez dos filtros individuais abaixo. Crie predefinições de filtro na vista principal da biblioteca do Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help">Selecione uma ou mais predefinições de filtro e/ou etiquetas. Os jogos que correspondam a qualquer predefinição ou etiqueta selecionada serão elegíveis para exportação (lógica OU). Crie predefinições de filtro primeiro na vista principal da biblioteca do Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterSearch_Tooltip">Filtre as listas por nome. Os itens assinalados permanecem selecionados quando ocultos.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly">Mostrar apenas assinalados</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly_Tooltip">Mostrar apenas predefinições e etiquetas que estão assinalados de momento.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterPresets">Predefinições de filtro</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterPresets_Selected">Predefinições de filtro ({0} selecionadas)</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_TagPresets">Predefinições de etiquetas</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_TagPresets_Selected">Predefinições de etiquetas ({0} selecionadas)</sys:String>
 
     <!-- Manage Games Tab -->
     <sys:String x:Key="LOC_ApolloSync_Settings_ManageGames">Gerir jogos exportados</sys:String>

--- a/Localization/ro_RO.xaml
+++ b/Localization/ro_RO.xaml
@@ -57,6 +57,17 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Folosește presetarea de filtru Playnite</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Când este activat, presetarea de filtru selectată va fi folosită în locul filtrelor individuale de mai jos. Creează presetări de filtru în vizualizarea principală a bibliotecii Playnite.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help">Selectează una sau mai multe presetări de filtru și/sau etichete. Jocurile care se potrivesc cu orice presetare sau etichetă selectată vor fi eligibile pentru export (logică SAU). Creează mai întâi presetări de filtru în vizualizarea principală a bibliotecii Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_Or">Selectează una sau mai multe presetări de filtru și/sau etichete. Jocurile care se potrivesc cu orice presetare sau etichetă selectată sunt eligibile pentru export (SAU). În fiecare listă, orice element bifat se potrivește.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_And">Selectează presetări de filtru deasupra și etichete dedesubt. Jocurile trebuie să se potrivească cu cel puțin o presetare bifată și cel puțin o etichetă bifată (ȘI). Dacă doar o listă are selecții, doar acea listă determină eligibilitatea.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_Not">Jocurile trebuie să se potrivească cu o presetare de filtru selectată, dar să nu aibă nicio etichetă selectată — util pentru exportul potrivirilor de presetare excluzând jocurile etichetate. Este necesară cel puțin o presetare de filtru; etichetele sunt excluderi opționale.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_CreatePresets">Creează mai întâi presetări de filtru în vizualizarea principală a bibliotecii Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination">Combină presetările și etichetele:</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Or">Oricare (SAU)</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_And">Ambele (ȘI)</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Not">Exclude etichetele</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Or_Tooltip">Exportă jocurile care se potrivesc cu orice presetare de filtru sau etichetă selectată.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_And_Tooltip">Exportă jocurile care se potrivesc cu cel puțin o presetare și cel puțin o etichetă selectate.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Not_Tooltip">Exportă jocurile care se potrivesc cu o presetare, dar nu au nicio etichetă selectată.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterSearch_Tooltip">Filtrează listele după nume. Elementele bifate rămân selectate când sunt ascunse.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly">Afișează doar bifate</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly_Tooltip">Afișează doar presetările și etichetele bifate în prezent.</sys:String>

--- a/Localization/ro_RO.xaml
+++ b/Localization/ro_RO.xaml
@@ -56,6 +56,14 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Presetare filtru</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Folosește presetarea de filtru Playnite</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Când este activat, presetarea de filtru selectată va fi folosită în locul filtrelor individuale de mai jos. Creează presetări de filtru în vizualizarea principală a bibliotecii Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help">Selectează una sau mai multe presetări de filtru și/sau etichete. Jocurile care se potrivesc cu orice presetare sau etichetă selectată vor fi eligibile pentru export (logică SAU). Creează mai întâi presetări de filtru în vizualizarea principală a bibliotecii Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterSearch_Tooltip">Filtrează listele după nume. Elementele bifate rămân selectate când sunt ascunse.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly">Afișează doar bifate</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly_Tooltip">Afișează doar presetările și etichetele bifate în prezent.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterPresets">Presetări filtru</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterPresets_Selected">Presetări filtru ({0} selectate)</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_TagPresets">Presetări etichete</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_TagPresets_Selected">Presetări etichete ({0} selectate)</sys:String>
 
     <!-- Manage Games Tab -->
     <sys:String x:Key="LOC_ApolloSync_Settings_ManageGames">Gestionează jocurile exportate</sys:String>

--- a/Localization/ru_RU.xaml
+++ b/Localization/ru_RU.xaml
@@ -57,6 +57,17 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Использовать предустановку фильтра Playnite</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Если включено, вместо отдельных фильтров ниже будет использоваться выбранная предустановка фильтра. Создавайте предустановки фильтров в главном представлении библиотеки Playnite.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help">Выберите одну или несколько предустановок фильтров и/или тегов. Игры, соответствующие любой выбранной предустановке или тегу, будут доступны для экспорта (логика ИЛИ). Сначала создайте предустановки фильтров в главном виде библиотеки Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_Or">Выберите одну или несколько предустановок фильтров и/или тегов. Игры, соответствующие любой выбранной предустановке или тегу, доступны для экспорта (ИЛИ). В каждом списке подходит любой отмеченный элемент.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_And">Выберите предустановки фильтров выше и теги ниже. Игра должна соответствовать хотя бы одной отмеченной предустановке и хотя бы одному отмеченному тегу (И). Если выбран только один список, решает только он.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_Not">Игра должна соответствовать выбранной предустановке фильтра, но не иметь ни одного выбранного тега — полезно для экспорта совпадений по предустановке без помеченных игр. Требуется хотя бы одна предустановка фильтра; теги — необязательные исключения.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_CreatePresets">Сначала создайте предустановки фильтров в главном виде библиотеки Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination">Объединить предустановки и теги:</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Or">Любой (ИЛИ)</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_And">Оба (И)</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Not">Исключить теги</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Or_Tooltip">Экспортировать игры, соответствующие любой выбранной предустановке фильтра или тегу.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_And_Tooltip">Экспортировать игры, соответствующие хотя бы одной выбранной предустановке и хотя бы одному выбранному тегу.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Not_Tooltip">Экспортировать игры, соответствующие предустановке, но без выбранных тегов.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterSearch_Tooltip">Фильтруйте списки по имени. Отмеченные элементы остаются выбранными, даже если скрыты.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly">Показывать только отмеченные</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly_Tooltip">Показывать только предустановки и теги, которые сейчас отмечены.</sys:String>

--- a/Localization/ru_RU.xaml
+++ b/Localization/ru_RU.xaml
@@ -56,6 +56,14 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Предустановка фильтра</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Использовать предустановку фильтра Playnite</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Если включено, вместо отдельных фильтров ниже будет использоваться выбранная предустановка фильтра. Создавайте предустановки фильтров в главном представлении библиотеки Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help">Выберите одну или несколько предустановок фильтров и/или тегов. Игры, соответствующие любой выбранной предустановке или тегу, будут доступны для экспорта (логика ИЛИ). Сначала создайте предустановки фильтров в главном виде библиотеки Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterSearch_Tooltip">Фильтруйте списки по имени. Отмеченные элементы остаются выбранными, даже если скрыты.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly">Показывать только отмеченные</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly_Tooltip">Показывать только предустановки и теги, которые сейчас отмечены.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterPresets">Предустановки фильтров</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterPresets_Selected">Предустановки фильтров ({0} выбрано)</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_TagPresets">Предустановки тегов</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_TagPresets_Selected">Предустановки тегов ({0} выбрано)</sys:String>
 
     <!-- Manage Games Tab -->
     <sys:String x:Key="LOC_ApolloSync_Settings_ManageGames">Управление экспортированными играми</sys:String>

--- a/Localization/sv_SE.xaml
+++ b/Localization/sv_SE.xaml
@@ -56,6 +56,14 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Filterförinställning</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Använd Playnite-filterförinställning</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">När aktiverat används den valda filterförinställningen istället för de enskilda filtren nedan. Skapa filterförinställningar i Playnites huvudbiblioteksvy.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help">Välj en eller flera filterförinställningar och/eller taggar. Spel som matchar valfri vald förinställning eller tagg är berättigade till export (ELLER-logik). Skapa filterförinställningar först i Playnites huvudbiblioteksvy.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterSearch_Tooltip">Filtrera listorna efter namn. Markerade objekt förblir valda när de döljs.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly">Visa endast markerade</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly_Tooltip">Visa endast förinställningar och taggar som för närvarande är markerade.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterPresets">Filterförinställningar</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterPresets_Selected">Filterförinställningar ({0} valda)</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_TagPresets">Taggförinställningar</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_TagPresets_Selected">Taggförinställningar ({0} valda)</sys:String>
 
     <!-- Manage Games Tab -->
     <sys:String x:Key="LOC_ApolloSync_Settings_ManageGames">Hantera exporterade spel</sys:String>

--- a/Localization/sv_SE.xaml
+++ b/Localization/sv_SE.xaml
@@ -57,6 +57,17 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Använd Playnite-filterförinställning</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">När aktiverat används den valda filterförinställningen istället för de enskilda filtren nedan. Skapa filterförinställningar i Playnites huvudbiblioteksvy.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help">Välj en eller flera filterförinställningar och/eller taggar. Spel som matchar valfri vald förinställning eller tagg är berättigade till export (ELLER-logik). Skapa filterförinställningar först i Playnites huvudbiblioteksvy.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_Or">Välj en eller flera filterförinställningar och/eller taggar. Spel som matchar valfri vald förinställning eller tagg är berättigade till export (ELLER). Inom varje lista matchar alla ikryssade objekt.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_And">Välj filterförinställningar ovan och taggar nedan. Spel måste matcha minst en ikryssad förinställning och minst en ikryssad tagg (OCH). Om bara en lista har val görs bedömningen enbart utifrån den listan.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_Not">Spel måste matcha en vald filterförinställning men får inte ha någon vald tagg — användbart för att exportera förinställningsmatchningar utan taggade spel. Minst en filterförinställning krävs; taggar är valfria undantag.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_CreatePresets">Skapa filterförinställningar först i Playnites huvudbiblioteksvy.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination">Kombinera förinställningar och taggar:</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Or">Valfri (ELLER)</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_And">Båda (OCH)</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Not">Exkludera taggar</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Or_Tooltip">Exportera spel som matchar valfri vald filterförinställning eller tagg.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_And_Tooltip">Exportera spel som matchar minst en vald förinställning och minst en vald tagg.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Not_Tooltip">Exportera spel som matchar en förinställning men inte har någon vald tagg.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterSearch_Tooltip">Filtrera listorna efter namn. Markerade objekt förblir valda när de döljs.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly">Visa endast markerade</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly_Tooltip">Visa endast förinställningar och taggar som för närvarande är markerade.</sys:String>

--- a/Localization/tr_TR.xaml
+++ b/Localization/tr_TR.xaml
@@ -57,6 +57,17 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Playnite Filtre Ön Ayarını Kullan</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Etkinleştirildiğinde, aşağıdaki ayrı filtreler yerine seçilen filtre ön ayarı kullanılır. Filtre ön ayarlarını Playnite'ın ana kütüphane görünümünde oluşturabilirsiniz.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help">Bir veya daha fazla filtre ön ayarı ve/veya etiket seçin. Seçili herhangi bir ön ayar veya etiketle eşleşen oyunlar dışa aktarım için uygun olur (VEYA mantığı). Önce Playnite ana kütüphane görünümünde filtre ön ayarları oluşturun.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_Or">Bir veya daha fazla filtre ön ayarı ve/veya etiket seçin. Seçili herhangi bir ön ayar veya etiketle eşleşen oyunlar dışa aktarım için uygundur (VEYA). Her listede işaretli herhangi bir öğe eşleşir.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_And">Yukarıda filtre ön ayarlarını, aşağıda etiketleri seçin. Oyunlar en az bir işaretli ön ayar ve en az bir işaretli etiketle eşleşmelidir (VE). Yalnızca bir listede seçim varsa yalnızca o liste geçerliliği belirler.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_Not">Oyunlar seçili bir filtre ön ayarıyla eşleşmeli ancak seçili bir etikete sahip olmamalıdır — ön ayar eşleşmelerini etiketli oyunları hariç tutarak dışa aktarmak için kullanışlıdır. En az bir filtre ön ayarı gerekir; etiketler isteğe bağlı hariç tutmalardır.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_CreatePresets">Önce Playnite ana kütüphane görünümünde filtre ön ayarları oluşturun.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination">Ön ayarları ve etiketleri birleştir:</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Or">Herhangi (VEYA)</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_And">Her ikisi (VE)</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Not">Etiketleri hariç tut</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Or_Tooltip">Seçili herhangi bir filtre ön ayarı veya etiketle eşleşen oyunları dışa aktar.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_And_Tooltip">En az bir seçili ön ayar ve en az bir seçili etiketle eşleşen oyunları dışa aktar.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Not_Tooltip">Bir ön ayarla eşleşen ancak seçili etiketi olmayan oyunları dışa aktar.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterSearch_Tooltip">Listeleri ada göre filtreleyin. Gizlendiğinde bile işaretli öğeler seçili kalır.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly">Yalnızca işaretlileri göster</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly_Tooltip">Yalnızca şu anda işaretli ön ayarları ve etiketleri göster.</sys:String>

--- a/Localization/tr_TR.xaml
+++ b/Localization/tr_TR.xaml
@@ -56,6 +56,14 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Filtre Ön Ayarı</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Playnite Filtre Ön Ayarını Kullan</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Etkinleştirildiğinde, aşağıdaki ayrı filtreler yerine seçilen filtre ön ayarı kullanılır. Filtre ön ayarlarını Playnite'ın ana kütüphane görünümünde oluşturabilirsiniz.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help">Bir veya daha fazla filtre ön ayarı ve/veya etiket seçin. Seçili herhangi bir ön ayar veya etiketle eşleşen oyunlar dışa aktarım için uygun olur (VEYA mantığı). Önce Playnite ana kütüphane görünümünde filtre ön ayarları oluşturun.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterSearch_Tooltip">Listeleri ada göre filtreleyin. Gizlendiğinde bile işaretli öğeler seçili kalır.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly">Yalnızca işaretlileri göster</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly_Tooltip">Yalnızca şu anda işaretli ön ayarları ve etiketleri göster.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterPresets">Filtre ön ayarları</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterPresets_Selected">Filtre ön ayarları ({0} seçili)</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_TagPresets">Etiket ön ayarları</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_TagPresets_Selected">Etiket ön ayarları ({0} seçili)</sys:String>
 
     <!-- Manage Games Tab -->
     <sys:String x:Key="LOC_ApolloSync_Settings_ManageGames">Aktarılan Oyunları Yönet</sys:String>

--- a/Localization/uk_UA.xaml
+++ b/Localization/uk_UA.xaml
@@ -56,6 +56,14 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Набір фільтрів</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Використовувати набір фільтрів Playnite</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Якщо увімкнено, замість окремих фільтрів нижче буде використовуватися вибраний набір фільтрів. Створюйте набори фільтрів у головному вигляді бібліотеки Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help">Виберіть одну або кілька наборів фільтрів і/або тегів. Ігри, що відповідають будь-якому вибраному набору або тегу, будуть доступні для експорту (логіка АБО). Спочатку створіть набори фільтрів у головному вигляді бібліотеки Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterSearch_Tooltip">Фільтруйте списки за назвою. Позначені елементи залишаються вибраними, навіть якщо приховані.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly">Показувати лише позначені</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly_Tooltip">Показувати лише набори та теги, які зараз позначені.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterPresets">Набори фільтрів</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterPresets_Selected">Набори фільтрів ({0} вибрано)</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_TagPresets">Набори тегів</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_TagPresets_Selected">Набори тегів ({0} вибрано)</sys:String>
 
     <!-- Manage Games Tab -->
     <sys:String x:Key="LOC_ApolloSync_Settings_ManageGames">Керування експортованими іграми</sys:String>

--- a/Localization/uk_UA.xaml
+++ b/Localization/uk_UA.xaml
@@ -57,6 +57,17 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Використовувати набір фільтрів Playnite</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Якщо увімкнено, замість окремих фільтрів нижче буде використовуватися вибраний набір фільтрів. Створюйте набори фільтрів у головному вигляді бібліотеки Playnite.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help">Виберіть одну або кілька наборів фільтрів і/або тегів. Ігри, що відповідають будь-якому вибраному набору або тегу, будуть доступні для експорту (логіка АБО). Спочатку створіть набори фільтрів у головному вигляді бібліотеки Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_Or">Виберіть одну або кілька наборів фільтрів і/або тегів. Ігри, що відповідають будь-якому вибраному набору або тегу, доступні для експорту (АБО). У кожному списку підходить будь-який позначений елемент.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_And">Виберіть набори фільтрів вище та теги нижче. Гра має відповідати щонайменше одному позначеному набору та щонайменше одному позначеному тегу (І). Якщо вибрано лише один список, рішення приймається лише за ним.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_Not">Гра має відповідати вибраному набору фільтрів, але не мати жодного вибраного тегу — корисно для експорту збігів набору без позначених ігор. Потрібен щонайменше один набір фільтрів; теги — необов'язкові виключення.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_CreatePresets">Спочатку створіть набори фільтрів у головному вигляді бібліотеки Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination">Поєднати набори та теги:</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Or">Будь-який (АБО)</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_And">Обидва (І)</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Not">Виключити теги</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Or_Tooltip">Експортувати ігри, що відповідають будь-якому вибраному набору фільтрів або тегу.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_And_Tooltip">Експортувати ігри, що відповідають щонайменше одному вибраному набору та щонайменше одному вибраному тегу.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Not_Tooltip">Експортувати ігри, що відповідають набору, але не мають вибраних тегів.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterSearch_Tooltip">Фільтруйте списки за назвою. Позначені елементи залишаються вибраними, навіть якщо приховані.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly">Показувати лише позначені</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly_Tooltip">Показувати лише набори та теги, які зараз позначені.</sys:String>

--- a/Localization/zh_CN.xaml
+++ b/Localization/zh_CN.xaml
@@ -56,6 +56,14 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">筛选预设</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">使用Playnite筛选预设</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">启用后，将使用所选的筛选预设替代下方的各项筛选条件。可在Playnite的主库视图中创建筛选预设。</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help">选择一个或多个筛选预设和/或标签。匹配任一所选预设或标签的游戏将有资格导出（OR逻辑）。请先在Playnite主库视图中创建筛选预设。</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterSearch_Tooltip">按名称筛选预设和标签列表。被筛掉的已勾选项仍保持选中状态。</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly">仅显示已勾选</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly_Tooltip">仅显示当前已勾选的预设和标签。</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterPresets">筛选预设</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterPresets_Selected">筛选预设（已选 {0} 项）</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_TagPresets">标签预设</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_TagPresets_Selected">标签预设（已选 {0} 项）</sys:String>
 
     <!-- Manage Games Tab -->
     <sys:String x:Key="LOC_ApolloSync_Settings_ManageGames">管理已导出的游戏</sys:String>

--- a/Localization/zh_CN.xaml
+++ b/Localization/zh_CN.xaml
@@ -57,6 +57,17 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">使用Playnite筛选预设</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">启用后，将使用所选的筛选预设替代下方的各项筛选条件。可在Playnite的主库视图中创建筛选预设。</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help">选择一个或多个筛选预设和/或标签。匹配任一所选预设或标签的游戏将有资格导出（OR逻辑）。请先在Playnite主库视图中创建筛选预设。</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_Or">选择一个或多个筛选预设和/或标签。匹配任一所选预设或标签的游戏可导出（OR）。每个列表内，任意勾选项均匹配。</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_And">在上方选择筛选预设，在下方选择标签。游戏必须同时匹配至少一个已勾选的预设和至少一个已勾选的标签（AND）。若仅一个列表有选择，则仅由该列表决定是否符合条件。</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_Not">游戏必须匹配所选筛选预设，且不得拥有任何所选标签——适用于导出预设匹配结果但排除已标记游戏。至少需选择一个筛选预设；标签为可选排除项。</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_CreatePresets">请先在Playnite主库视图中创建筛选预设。</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination">组合预设与标签：</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Or">任一（OR）</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_And">两者（AND）</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Not">排除标签</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Or_Tooltip">导出匹配任一所选筛选预设或标签的游戏。</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_And_Tooltip">导出同时匹配至少一个所选预设和至少一个所选标签的游戏。</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Not_Tooltip">导出匹配预设但不拥有任何所选标签的游戏。</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterSearch_Tooltip">按名称筛选预设和标签列表。被筛掉的已勾选项仍保持选中状态。</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly">仅显示已勾选</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly_Tooltip">仅显示当前已勾选的预设和标签。</sys:String>

--- a/Localization/zh_TW.xaml
+++ b/Localization/zh_TW.xaml
@@ -57,6 +57,17 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">使用Playnite篩選預設</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">啟用後，將使用所選的篩選預設取代下方的各項篩選條件。可在Playnite的主媒體庫檢視中建立篩選預設。</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help">選擇一個或多個篩選預設和/或標籤。符合任一所選預設或標籤的遊戲將符合匯出資格（OR邏輯）。請先在Playnite主媒體庫檢視中建立篩選預設。</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_Or">選擇一個或多個篩選預設和/或標籤。符合任一所選預設或標籤的遊戲可匯出（OR）。每個清單內，任何勾選項目皆符合。</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_And">在上方選擇篩選預設，在下方選擇標籤。遊戲必須同時符合至少一個已勾選的預設和至少一個已勾選的標籤（AND）。若僅一個清單有選擇，則僅由該清單決定是否符合條件。</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_Not">遊戲必須符合所選篩選預設，且不得擁有任何所選標籤——適用於匯出預設符合結果但排除已標記遊戲。至少需選擇一個篩選預設；標籤為選用排除項。</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help_CreatePresets">請先在Playnite主媒體庫檢視中建立篩選預設。</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination">組合預設與標籤：</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Or">任一（OR）</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_And">兩者（AND）</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Not">排除標籤</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Or_Tooltip">匯出符合任一所選篩選預設或標籤的遊戲。</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_And_Tooltip">匯出同時符合至少一個所選預設和至少一個所選標籤的遊戲。</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_PresetTagCombination_Not_Tooltip">匯出符合預設但不擁有任何所選標籤的遊戲。</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterSearch_Tooltip">依名稱篩選預設和標籤清單。被篩掉的已勾選項目仍保持選取狀態。</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly">僅顯示已勾選</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly_Tooltip">僅顯示目前已勾選的預設和標籤。</sys:String>

--- a/Localization/zh_TW.xaml
+++ b/Localization/zh_TW.xaml
@@ -56,6 +56,14 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">篩選預設</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">使用Playnite篩選預設</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">啟用後，將使用所選的篩選預設取代下方的各項篩選條件。可在Playnite的主媒體庫檢視中建立篩選預設。</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_Filters_Help">選擇一個或多個篩選預設和/或標籤。符合任一所選預設或標籤的遊戲將符合匯出資格（OR邏輯）。請先在Playnite主媒體庫檢視中建立篩選預設。</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterSearch_Tooltip">依名稱篩選預設和標籤清單。被篩掉的已勾選項目仍保持選取狀態。</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly">僅顯示已勾選</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ShowCheckedOnly_Tooltip">僅顯示目前已勾選的預設和標籤。</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterPresets">篩選預設</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_FilterPresets_Selected">篩選預設（已選 {0} 項）</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_TagPresets">標籤預設</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_TagPresets_Selected">標籤預設（已選 {0} 項）</sys:String>
 
     <!-- Manage Games Tab -->
     <sys:String x:Key="LOC_ApolloSync_Settings_ManageGames">管理已匯出的遊戲</sys:String>

--- a/Settings/ApolloSyncSettings.cs
+++ b/Settings/ApolloSyncSettings.cs
@@ -16,6 +16,13 @@ namespace ApolloSync
         Never
     }
 
+    public enum PresetTagCombinationMode
+    {
+        Or,
+        And,
+        Not
+    }
+
     public class LabelOption
     {
         public string Name { get; set; }
@@ -79,6 +86,13 @@ namespace ApolloSync
         {
             get => _includedTagIds;
             set => SetValue(ref _includedTagIds, value);
+        }
+
+        private PresetTagCombinationMode _presetTagCombinationMode = PresetTagCombinationMode.Or;
+        public PresetTagCombinationMode PresetTagCombinationMode
+        {
+            get => _presetTagCombinationMode;
+            set => SetValue(ref _presetTagCombinationMode, value);
         }
 
         private bool _showNotifications = true;

--- a/Settings/ApolloSyncSettings.cs
+++ b/Settings/ApolloSyncSettings.cs
@@ -74,6 +74,13 @@ namespace ApolloSync
             set => SetValue(ref _includedFilterPresetIds, value);
         }
 
+        private List<Guid> _includedTagIds = new List<Guid>();
+        public List<Guid> IncludedTagIds
+        {
+            get => _includedTagIds;
+            set => SetValue(ref _includedTagIds, value);
+        }
+
         private bool _showNotifications = true;
         public bool ShowNotifications
         {
@@ -116,6 +123,7 @@ namespace ApolloSync
         }
 
         public List<FilterPreset> AvailableFilterPresets { get; private set; }
+        public List<Tag> AvailableTags { get; private set; }
 
         public List<Game> GetManagedGames()
         {
@@ -159,6 +167,7 @@ namespace ApolloSync
             if (_plugin.PlayniteApi?.Database != null)
             {
                 AvailableFilterPresets = _plugin.PlayniteApi.Database.FilterPresets.OrderBy(f => f.Name).ToList();
+                AvailableTags = _plugin.PlayniteApi.Database.Tags.OrderBy(t => t.Name).ToList();
             }
         }
 

--- a/Settings/ApolloSyncSettingsView.xaml.cs
+++ b/Settings/ApolloSyncSettingsView.xaml.cs
@@ -225,7 +225,7 @@ namespace ApolloSync
         {
             var grid = new Grid { Margin = new Thickness(8) };
             grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });                                   // 0: help text
-            grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });                                   // 1: search box
+            grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });                                   // 1: search controls
             grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });                                   // 2: platform (collapsed)
             grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });                                   // 3: label (collapsed)
             grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });                                   // 4: completion (collapsed)
@@ -245,27 +245,15 @@ namespace ApolloSync
             Grid.SetRow(helpText, 0);
             grid.Children.Add(helpText);
 
-            // Search row: search box (left, fills width) + show-checked toggle (right, outside border)
-            var searchRow = new DockPanel { Margin = new Thickness(0, 0, 0, 8), LastChildFill = true };
-
-            var showCheckedCheckBox = new CheckBox
-            {
-                Content = ResourceProvider.GetString("LOC_ApolloSync_Settings_ShowCheckedOnly"),
-                ToolTip = ResourceProvider.GetString("LOC_ApolloSync_Settings_ShowCheckedOnly_Tooltip"),
-                VerticalAlignment = VerticalAlignment.Center,
-                Margin = new Thickness(12, 0, 0, 0)
-            };
-            showCheckedCheckBox.Checked += ShowCheckedOnly_Changed;
-            showCheckedCheckBox.Unchecked += ShowCheckedOnly_Changed;
-            DockPanel.SetDock(showCheckedCheckBox, Dock.Right);
-            searchRow.Children.Add(showCheckedCheckBox);
+            // Search box and show-checked toggle (separate rows)
+            var searchSection = new StackPanel { Margin = new Thickness(0, 0, 0, 8) };
 
             var searchBorder = new Border
             {
-                BorderBrush = System.Windows.Media.Brushes.Gray,
-                BorderThickness = new Thickness(1),
-                CornerRadius = new CornerRadius(2),
-                Padding = new Thickness(6, 3, 6, 3),
+                BorderBrush = Brushes.Silver,
+                BorderThickness = new Thickness(2),
+                CornerRadius = new CornerRadius(3),
+                Padding = new Thickness(6, 4, 6, 4),
                 ToolTip = ResourceProvider.GetString("LOC_ApolloSync_Settings_FilterSearch_Tooltip")
             };
             var searchDock = new DockPanel { LastChildFill = true };
@@ -276,7 +264,7 @@ namespace ApolloSync
                 FontSize = 13,
                 VerticalAlignment = VerticalAlignment.Center,
                 Margin = new Thickness(0, 0, 6, 0),
-                Foreground = System.Windows.Media.Brushes.Gray
+                Foreground = Brushes.Silver
             };
             DockPanel.SetDock(searchIcon, Dock.Left);
             searchDock.Children.Add(searchIcon);
@@ -290,10 +278,20 @@ namespace ApolloSync
             searchBox.TextChanged += FilterSearch_TextChanged;
             searchDock.Children.Add(searchBox);
             searchBorder.Child = searchDock;
-            searchRow.Children.Add(searchBorder);
+            searchSection.Children.Add(searchBorder);
 
-            Grid.SetRow(searchRow, 1);
-            grid.Children.Add(searchRow);
+            var showCheckedCheckBox = new CheckBox
+            {
+                Content = ResourceProvider.GetString("LOC_ApolloSync_Settings_ShowCheckedOnly"),
+                ToolTip = ResourceProvider.GetString("LOC_ApolloSync_Settings_ShowCheckedOnly_Tooltip"),
+                Margin = new Thickness(0, 6, 0, 0)
+            };
+            showCheckedCheckBox.Checked += ShowCheckedOnly_Changed;
+            showCheckedCheckBox.Unchecked += ShowCheckedOnly_Changed;
+            searchSection.Children.Add(showCheckedCheckBox);
+
+            Grid.SetRow(searchSection, 1);
+            grid.Children.Add(searchSection);
 
             // Platform Filters (collapsible)
             var platformExpander = new Expander

--- a/Settings/ApolloSyncSettingsView.xaml.cs
+++ b/Settings/ApolloSyncSettingsView.xaml.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Data;
 using System.Windows.Media;
 using Microsoft.Win32;
@@ -14,6 +15,8 @@ namespace ApolloSync
     public partial class ApolloSyncSettingsView : UserControl
     {
         private static readonly ILogger logger = LogManager.GetLogger();
+        private string _filterSearchText = "";
+        private bool _showCheckedOnly = false;
 
         public ApolloSyncSettingsView()
         {
@@ -218,9 +221,79 @@ namespace ApolloSync
             return stack;
         }
 
-        private StackPanel BuildFiltersTab()
+        private FrameworkElement BuildFiltersTab()
         {
-            var stack = new StackPanel { Margin = new Thickness(8) };
+            var grid = new Grid { Margin = new Thickness(8) };
+            grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });                                   // 0: help text
+            grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });                                   // 1: search box
+            grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });                                   // 2: platform (collapsed)
+            grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });                                   // 3: label (collapsed)
+            grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });                                   // 4: completion (collapsed)
+            grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });                                   // 5: filter presets
+            grid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Star) });              // 6: tags (fill remaining)
+            grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });                                   // 7: category (collapsed)
+
+            // Top-level help text
+            var helpText = new TextBlock
+            {
+                Text = ResourceProvider.GetString("LOC_ApolloSync_Settings_Filters_Help"),
+                TextWrapping = TextWrapping.Wrap,
+                Margin = new Thickness(0, 0, 0, 8),
+                Foreground = System.Windows.Media.Brushes.Gray,
+                FontStyle = FontStyles.Italic
+            };
+            Grid.SetRow(helpText, 0);
+            grid.Children.Add(helpText);
+
+            // Search row: search box (left, fills width) + show-checked toggle (right, outside border)
+            var searchRow = new DockPanel { Margin = new Thickness(0, 0, 0, 8), LastChildFill = true };
+
+            var showCheckedCheckBox = new CheckBox
+            {
+                Content = ResourceProvider.GetString("LOC_ApolloSync_Settings_ShowCheckedOnly"),
+                ToolTip = ResourceProvider.GetString("LOC_ApolloSync_Settings_ShowCheckedOnly_Tooltip"),
+                VerticalAlignment = VerticalAlignment.Center,
+                Margin = new Thickness(12, 0, 0, 0)
+            };
+            showCheckedCheckBox.Checked += ShowCheckedOnly_Changed;
+            showCheckedCheckBox.Unchecked += ShowCheckedOnly_Changed;
+            DockPanel.SetDock(showCheckedCheckBox, Dock.Right);
+            searchRow.Children.Add(showCheckedCheckBox);
+
+            var searchBorder = new Border
+            {
+                BorderBrush = System.Windows.Media.Brushes.Gray,
+                BorderThickness = new Thickness(1),
+                CornerRadius = new CornerRadius(2),
+                Padding = new Thickness(6, 3, 6, 3),
+                ToolTip = ResourceProvider.GetString("LOC_ApolloSync_Settings_FilterSearch_Tooltip")
+            };
+            var searchDock = new DockPanel { LastChildFill = true };
+            var searchIcon = new TextBlock
+            {
+                Text = "\uE721",
+                FontFamily = new FontFamily("Segoe MDL2 Assets"),
+                FontSize = 13,
+                VerticalAlignment = VerticalAlignment.Center,
+                Margin = new Thickness(0, 0, 6, 0),
+                Foreground = System.Windows.Media.Brushes.Gray
+            };
+            DockPanel.SetDock(searchIcon, Dock.Left);
+            searchDock.Children.Add(searchIcon);
+            var searchBox = new TextBox
+            {
+                BorderThickness = new Thickness(0),
+                Background = Brushes.Transparent,
+                VerticalAlignment = VerticalAlignment.Center,
+                ToolTip = ResourceProvider.GetString("LOC_ApolloSync_Settings_FilterSearch_Tooltip")
+            };
+            searchBox.TextChanged += FilterSearch_TextChanged;
+            searchDock.Children.Add(searchBox);
+            searchBorder.Child = searchDock;
+            searchRow.Children.Add(searchBorder);
+
+            Grid.SetRow(searchRow, 1);
+            grid.Children.Add(searchRow);
 
             // Platform Filters (collapsible)
             var platformExpander = new Expander
@@ -273,7 +346,8 @@ namespace ApolloSync
 
             platformExpander.Content = platformContentPanel;
             platformExpander.Visibility = Visibility.Collapsed; // TEMP: Disable custom filters
-            stack.Children.Add(platformExpander);
+            Grid.SetRow(platformExpander, 2);
+            grid.Children.Add(platformExpander);
 
             // Label Filter (collapsible)
             var labelExpander = new Expander
@@ -304,7 +378,8 @@ namespace ApolloSync
 
             labelExpander.Content = labelContentPanel;
             labelExpander.Visibility = Visibility.Collapsed; // TEMP: Disable custom filters
-            stack.Children.Add(labelExpander);
+            Grid.SetRow(labelExpander, 3);
+            grid.Children.Add(labelExpander);
 
             // Completion Status Filter (collapsible)
             var completionExpander = new Expander
@@ -357,12 +432,14 @@ namespace ApolloSync
 
             completionExpander.Content = completionContentPanel;
             completionExpander.Visibility = Visibility.Collapsed; // TEMP: Disable custom filters
-            stack.Children.Add(completionExpander);
+            Grid.SetRow(completionExpander, 4);
+            grid.Children.Add(completionExpander);
 
             // Filter Presets (collapsible)
             var filterPresetExpander = new Expander
             {
-                Header = "Filter Presets",
+                Name = "FilterPresetExpander",
+                Header = ResourceProvider.GetString("LOC_ApolloSync_Settings_FilterPresets"),
                 IsExpanded = true,
                 Margin = new Thickness(0, 0, 0, 8)
             };
@@ -378,7 +455,7 @@ namespace ApolloSync
             };
 
             var filterPresetScrollViewer = new ScrollViewer { MaxHeight = 150, VerticalScrollBarVisibility = ScrollBarVisibility.Auto };
-            var filterPresetPanel = new StackPanel { Name = "FilterPresetsPanel" };
+            var filterPresetPanel = new UniformGrid { Name = "FilterPresetsPanel", Columns = 3 };
             filterPresetScrollViewer.Content = filterPresetPanel;
             filterPresetBorder.Child = filterPresetScrollViewer;
             filterPresetContentPanel.Children.Add(filterPresetBorder);
@@ -393,16 +470,6 @@ namespace ApolloSync
             filterPresetButtonPanel.Children.Add(clearAllFilterPresetBtn);
             filterPresetContentPanel.Children.Add(filterPresetButtonPanel);
 
-            // Help text
-            filterPresetContentPanel.Children.Add(new TextBlock
-            {
-                Text = "Select one or more filter presets. Games that match ANY selected preset will be eligible for export (OR logic). Create filter presets in Playnite's main library view first.",
-                TextWrapping = TextWrapping.Wrap,
-                Margin = new Thickness(0, 4, 0, 0),
-                Foreground = System.Windows.Media.Brushes.Gray,
-                FontStyle = FontStyles.Italic
-            });
-
             // Populate filter presets when DataContext is available
             if (DataContext is ApolloSyncSettingsViewModel vm4)
             {
@@ -413,11 +480,69 @@ namespace ApolloSync
                 if (DataContext is ApolloSyncSettingsViewModel viewModel4)
                 {
                     UpdateFilterPresetCheckboxes(filterPresetPanel);
+                    UpdateCheckedCounts();
                 }
             };
 
             filterPresetExpander.Content = filterPresetContentPanel;
-            stack.Children.Add(filterPresetExpander);
+            Grid.SetRow(filterPresetExpander, 5);
+            grid.Children.Add(filterPresetExpander);
+
+            // Tag Presets (collapsible, fills remaining window height)
+            var tagExpander = new Expander
+            {
+                Name = "TagExpander",
+                Header = ResourceProvider.GetString("LOC_ApolloSync_Settings_TagPresets"),
+                IsExpanded = true,
+                Margin = new Thickness(0, 0, 0, 8),
+                VerticalAlignment = VerticalAlignment.Stretch
+            };
+
+            // Inner grid: scroll area gets * height, buttons get Auto height
+            var tagContentPanel = new Grid();
+            tagContentPanel.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Star) });
+            tagContentPanel.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+
+            var tagBorder = new Border
+            {
+                BorderBrush = System.Windows.Media.Brushes.Gray,
+                BorderThickness = new Thickness(1),
+                Margin = new Thickness(0, 4, 0, 0)
+            };
+
+            var tagScrollViewer = new ScrollViewer { VerticalScrollBarVisibility = ScrollBarVisibility.Auto };
+            var tagsPanel = new UniformGrid { Name = "TagsPanel", Columns = 3 };
+            tagScrollViewer.Content = tagsPanel;
+            tagBorder.Child = tagScrollViewer;
+            Grid.SetRow(tagBorder, 0);
+            tagContentPanel.Children.Add(tagBorder);
+
+            var tagButtonPanel = new StackPanel { Orientation = Orientation.Horizontal, Margin = new Thickness(0, 4, 0, 0) };
+            var selectAllTagsBtn = new Button { Content = "Select All", Width = 80, Margin = new Thickness(0, 0, 4, 0) };
+            var clearAllTagsBtn = new Button { Content = "Clear All", Width = 80 };
+            selectAllTagsBtn.Click += SelectAllTags_Click;
+            clearAllTagsBtn.Click += ClearAllTags_Click;
+            tagButtonPanel.Children.Add(selectAllTagsBtn);
+            tagButtonPanel.Children.Add(clearAllTagsBtn);
+            Grid.SetRow(tagButtonPanel, 1);
+            tagContentPanel.Children.Add(tagButtonPanel);
+
+            if (DataContext is ApolloSyncSettingsViewModel vm5)
+            {
+                UpdateTagCheckboxes(tagsPanel);
+            }
+            DataContextChanged += (s, e) =>
+            {
+                if (DataContext is ApolloSyncSettingsViewModel viewModel5)
+                {
+                    UpdateTagCheckboxes(tagsPanel);
+                    UpdateCheckedCounts();
+                }
+            };
+
+            tagExpander.Content = tagContentPanel;
+            Grid.SetRow(tagExpander, 6);
+            grid.Children.Add(tagExpander);
 
             // Category Filter (collapsible)
             var categoryExpander = new Expander
@@ -470,9 +595,10 @@ namespace ApolloSync
 
             categoryExpander.Content = categoryContentPanel;
             categoryExpander.Visibility = Visibility.Collapsed; // TEMP: Disable custom filters
-            stack.Children.Add(categoryExpander);
+            Grid.SetRow(categoryExpander, 7);
+            grid.Children.Add(categoryExpander);
 
-            return stack;
+            return grid;
         }
 
         private StackPanel BuildManageGamesTab()
@@ -526,7 +652,7 @@ namespace ApolloSync
 
         #region Filter Preset Methods
 
-        private void UpdateFilterPresetCheckboxes(StackPanel filterPresetPanel)
+        private void UpdateFilterPresetCheckboxes(Panel filterPresetPanel)
         {
             filterPresetPanel.Children.Clear();
 
@@ -541,11 +667,18 @@ namespace ApolloSync
                 {
                     foreach (var filterPreset in vm.AvailableFilterPresets)
                     {
+                        if (!string.IsNullOrEmpty(_filterSearchText) &&
+                            filterPreset.Name.IndexOf(_filterSearchText, StringComparison.OrdinalIgnoreCase) < 0)
+                            continue;
+
+                        if (_showCheckedOnly && !vm.Settings.IncludedFilterPresetIds.Contains(filterPreset.Id))
+                            continue;
+
                         var checkbox = new CheckBox
                         {
                             Content = filterPreset.Name,
                             Tag = filterPreset.Id,
-                            Margin = new Thickness(0, 2, 0, 2)
+                            Margin = new Thickness(0, 2, 4, 2)
                         };
 
                         checkbox.IsChecked = vm.Settings.IncludedFilterPresetIds.Contains(filterPreset.Id);
@@ -563,21 +696,32 @@ namespace ApolloSync
         {
             if (DataContext is ApolloSyncSettingsViewModel vm && vm.AvailableFilterPresets != null)
             {
-                vm.Settings.IncludedFilterPresetIds.Clear();
                 foreach (var filterPreset in vm.AvailableFilterPresets)
                 {
-                    vm.Settings.IncludedFilterPresetIds.Add(filterPreset.Id);
+                    if (!string.IsNullOrEmpty(_filterSearchText) &&
+                        filterPreset.Name.IndexOf(_filterSearchText, StringComparison.OrdinalIgnoreCase) < 0)
+                        continue;
+                    if (!vm.Settings.IncludedFilterPresetIds.Contains(filterPreset.Id))
+                        vm.Settings.IncludedFilterPresetIds.Add(filterPreset.Id);
                 }
-                UpdateFilterPresetCheckboxes(FindChild<StackPanel>(this, "FilterPresetsPanel"));
+                UpdateFilterPresetCheckboxes(FindChild<UniformGrid>(this, "FilterPresetsPanel"));
+                UpdateCheckedCounts();
             }
         }
 
         private void ClearAllFilterPresets_Click(object sender, RoutedEventArgs e)
         {
-            if (DataContext is ApolloSyncSettingsViewModel vm)
+            if (DataContext is ApolloSyncSettingsViewModel vm && vm.AvailableFilterPresets != null)
             {
-                vm.Settings.IncludedFilterPresetIds.Clear();
-                UpdateFilterPresetCheckboxes(FindChild<StackPanel>(this, "FilterPresetsPanel"));
+                foreach (var filterPreset in vm.AvailableFilterPresets)
+                {
+                    if (!string.IsNullOrEmpty(_filterSearchText) &&
+                        filterPreset.Name.IndexOf(_filterSearchText, StringComparison.OrdinalIgnoreCase) < 0)
+                        continue;
+                    vm.Settings.IncludedFilterPresetIds.Remove(filterPreset.Id);
+                }
+                UpdateFilterPresetCheckboxes(FindChild<UniformGrid>(this, "FilterPresetsPanel"));
+                UpdateCheckedCounts();
             }
         }
 
@@ -586,13 +730,154 @@ namespace ApolloSync
             if (DataContext is ApolloSyncSettingsViewModel vm)
             {
                 if (isChecked && !vm.Settings.IncludedFilterPresetIds.Contains(presetId))
-                {
                     vm.Settings.IncludedFilterPresetIds.Add(presetId);
-                }
                 else if (!isChecked && vm.Settings.IncludedFilterPresetIds.Contains(presetId))
-                {
                     vm.Settings.IncludedFilterPresetIds.Remove(presetId);
+
+                if (_showCheckedOnly)
+                    UpdateFilterPresetCheckboxes(FindChild<UniformGrid>(this, "FilterPresetsPanel"));
+                UpdateCheckedCounts();
+            }
+        }
+
+        #endregion
+
+        #region Search
+
+        private void FilterSearch_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            _filterSearchText = ((TextBox)sender).Text;
+            var presetsPanel = FindChild<UniformGrid>(this, "FilterPresetsPanel");
+            if (presetsPanel != null)
+                UpdateFilterPresetCheckboxes(presetsPanel);
+            var tagsPanel = FindChild<UniformGrid>(this, "TagsPanel");
+            if (tagsPanel != null)
+                UpdateTagCheckboxes(tagsPanel);
+        }
+
+        private void ShowCheckedOnly_Changed(object sender, RoutedEventArgs e)
+        {
+            _showCheckedOnly = ((CheckBox)sender).IsChecked == true;
+            var presetsPanel = FindChild<UniformGrid>(this, "FilterPresetsPanel");
+            if (presetsPanel != null)
+                UpdateFilterPresetCheckboxes(presetsPanel);
+            var tagsPanel = FindChild<UniformGrid>(this, "TagsPanel");
+            if (tagsPanel != null)
+                UpdateTagCheckboxes(tagsPanel);
+        }
+
+        private void UpdateCheckedCounts()
+        {
+            if (!(DataContext is ApolloSyncSettingsViewModel vm)) return;
+
+            var presetExpander = FindChild<Expander>(this, "FilterPresetExpander");
+            if (presetExpander != null)
+            {
+                var count = vm.Settings.IncludedFilterPresetIds.Count;
+                presetExpander.Header = count > 0
+                    ? string.Format(ResourceProvider.GetString("LOC_ApolloSync_Settings_FilterPresets_Selected"), count)
+                    : ResourceProvider.GetString("LOC_ApolloSync_Settings_FilterPresets");
+            }
+
+            var tagExpander = FindChild<Expander>(this, "TagExpander");
+            if (tagExpander != null)
+            {
+                var count = vm.Settings.IncludedTagIds.Count;
+                tagExpander.Header = count > 0
+                    ? string.Format(ResourceProvider.GetString("LOC_ApolloSync_Settings_TagPresets_Selected"), count)
+                    : ResourceProvider.GetString("LOC_ApolloSync_Settings_TagPresets");
+            }
+        }
+
+        #endregion
+
+        #region Tag Methods
+
+        private void UpdateTagCheckboxes(Panel tagsPanel)
+        {
+            tagsPanel.Children.Clear();
+
+            if (DataContext is ApolloSyncSettingsViewModel vm)
+            {
+                if (vm.AvailableTags == null || vm.AvailableTags.Count == 0)
+                {
+                    vm.RefreshFilterPresets();
                 }
+
+                if (vm.AvailableTags != null)
+                {
+                    foreach (var tag in vm.AvailableTags)
+                    {
+                        if (!string.IsNullOrEmpty(_filterSearchText) &&
+                            tag.Name.IndexOf(_filterSearchText, StringComparison.OrdinalIgnoreCase) < 0)
+                            continue;
+
+                        if (_showCheckedOnly && !vm.Settings.IncludedTagIds.Contains(tag.Id))
+                            continue;
+
+                        var checkbox = new CheckBox
+                        {
+                            Content = tag.Name,
+                            Tag = tag.Id,
+                            Margin = new Thickness(0, 2, 4, 2)
+                        };
+
+                        checkbox.IsChecked = vm.Settings.IncludedTagIds.Contains(tag.Id);
+
+                        checkbox.Checked += (s, e) => OnTagCheckboxChanged(tag.Id, true);
+                        checkbox.Unchecked += (s, e) => OnTagCheckboxChanged(tag.Id, false);
+
+                        tagsPanel.Children.Add(checkbox);
+                    }
+                }
+            }
+        }
+
+        private void SelectAllTags_Click(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is ApolloSyncSettingsViewModel vm && vm.AvailableTags != null)
+            {
+                foreach (var tag in vm.AvailableTags)
+                {
+                    if (!string.IsNullOrEmpty(_filterSearchText) &&
+                        tag.Name.IndexOf(_filterSearchText, StringComparison.OrdinalIgnoreCase) < 0)
+                        continue;
+                    if (!vm.Settings.IncludedTagIds.Contains(tag.Id))
+                        vm.Settings.IncludedTagIds.Add(tag.Id);
+                }
+                UpdateTagCheckboxes(FindChild<UniformGrid>(this, "TagsPanel"));
+                UpdateCheckedCounts();
+            }
+        }
+
+        private void ClearAllTags_Click(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is ApolloSyncSettingsViewModel vm && vm.AvailableTags != null)
+            {
+                foreach (var tag in vm.AvailableTags)
+                {
+                    if (!string.IsNullOrEmpty(_filterSearchText) &&
+                        tag.Name.IndexOf(_filterSearchText, StringComparison.OrdinalIgnoreCase) < 0)
+                        continue;
+                    vm.Settings.IncludedTagIds.Remove(tag.Id);
+                }
+                UpdateTagCheckboxes(FindChild<UniformGrid>(this, "TagsPanel"));
+                UpdateCheckedCounts();
+            }
+        }
+
+        private void OnTagCheckboxChanged(Guid tagId, bool isChecked)
+        {
+            if (DataContext is ApolloSyncSettingsViewModel vm)
+            {
+                if (isChecked && !vm.Settings.IncludedTagIds.Contains(tagId))
+                    vm.Settings.IncludedTagIds.Add(tagId);
+                else if (!isChecked && vm.Settings.IncludedTagIds.Contains(tagId))
+                    vm.Settings.IncludedTagIds.Remove(tagId);
+
+                if (_showCheckedOnly)
+                    UpdateTagCheckboxes(FindChild<UniformGrid>(this, "TagsPanel"));
+                UpdateCheckedCounts();
             }
         }
 

--- a/Settings/ApolloSyncSettingsView.xaml.cs
+++ b/Settings/ApolloSyncSettingsView.xaml.cs
@@ -17,6 +17,10 @@ namespace ApolloSync
         private static readonly ILogger logger = LogManager.GetLogger();
         private string _filterSearchText = "";
         private bool _showCheckedOnly = false;
+        private TextBlock _filtersHelpText;
+        private ToggleButton _combinationOrButton;
+        private ToggleButton _combinationAndButton;
+        private ToggleButton _combinationNotButton;
 
         public ApolloSyncSettingsView()
         {
@@ -230,20 +234,21 @@ namespace ApolloSync
             grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });                                   // 3: label (collapsed)
             grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });                                   // 4: completion (collapsed)
             grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });                                   // 5: filter presets
-            grid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Star) });              // 6: tags (fill remaining)
-            grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });                                   // 7: category (collapsed)
+            grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });                                   // 6: preset/tag combination
+            grid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Star) });              // 7: tags (fill remaining)
+            grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });                                   // 8: category (collapsed)
 
-            // Top-level help text
-            var helpText = new TextBlock
+            // Top-level help text (updated when combination mode changes)
+            _filtersHelpText = new TextBlock
             {
-                Text = ResourceProvider.GetString("LOC_ApolloSync_Settings_Filters_Help"),
+                Name = "FiltersHelpText",
                 TextWrapping = TextWrapping.Wrap,
                 Margin = new Thickness(0, 0, 0, 8),
                 Foreground = System.Windows.Media.Brushes.Gray,
                 FontStyle = FontStyles.Italic
             };
-            Grid.SetRow(helpText, 0);
-            grid.Children.Add(helpText);
+            Grid.SetRow(_filtersHelpText, 0);
+            grid.Children.Add(_filtersHelpText);
 
             // Search box and show-checked toggle (separate rows)
             var searchSection = new StackPanel { Margin = new Thickness(0, 0, 0, 8) };
@@ -479,12 +484,49 @@ namespace ApolloSync
                 {
                     UpdateFilterPresetCheckboxes(filterPresetPanel);
                     UpdateCheckedCounts();
+                    UpdatePresetTagCombinationUi();
                 }
             };
 
             filterPresetExpander.Content = filterPresetContentPanel;
             Grid.SetRow(filterPresetExpander, 5);
             grid.Children.Add(filterPresetExpander);
+
+            // Preset/tag combination mode (between filter presets and tags)
+            var combinationPanel = new StackPanel
+            {
+                Name = "PresetTagCombinationPanel",
+                Orientation = Orientation.Horizontal,
+                Margin = new Thickness(0, 0, 0, 8)
+            };
+            var combinationLabel = new TextBlock
+            {
+                Text = ResourceProvider.GetString("LOC_ApolloSync_Settings_PresetTagCombination"),
+                VerticalAlignment = VerticalAlignment.Center,
+                Margin = new Thickness(0, 0, 8, 0)
+            };
+            combinationPanel.Children.Add(combinationLabel);
+
+            _combinationOrButton = CreateCombinationModeButton(
+                ResourceProvider.GetString("LOC_ApolloSync_Settings_PresetTagCombination_Or"),
+                ResourceProvider.GetString("LOC_ApolloSync_Settings_PresetTagCombination_Or_Tooltip"),
+                PresetTagCombinationMode.Or);
+            _combinationAndButton = CreateCombinationModeButton(
+                ResourceProvider.GetString("LOC_ApolloSync_Settings_PresetTagCombination_And"),
+                ResourceProvider.GetString("LOC_ApolloSync_Settings_PresetTagCombination_And_Tooltip"),
+                PresetTagCombinationMode.And);
+            _combinationNotButton = CreateCombinationModeButton(
+                ResourceProvider.GetString("LOC_ApolloSync_Settings_PresetTagCombination_Not"),
+                ResourceProvider.GetString("LOC_ApolloSync_Settings_PresetTagCombination_Not_Tooltip"),
+                PresetTagCombinationMode.Not);
+
+            combinationPanel.Children.Add(_combinationOrButton);
+            combinationPanel.Children.Add(_combinationAndButton);
+            combinationPanel.Children.Add(_combinationNotButton);
+            Grid.SetRow(combinationPanel, 6);
+            grid.Children.Add(combinationPanel);
+
+            UpdatePresetTagCombinationUi();
 
             // Tag Presets (collapsible, fills remaining window height)
             var tagExpander = new Expander
@@ -539,7 +581,7 @@ namespace ApolloSync
             };
 
             tagExpander.Content = tagContentPanel;
-            Grid.SetRow(tagExpander, 6);
+            Grid.SetRow(tagExpander, 7);
             grid.Children.Add(tagExpander);
 
             // Category Filter (collapsible)
@@ -593,7 +635,7 @@ namespace ApolloSync
 
             categoryExpander.Content = categoryContentPanel;
             categoryExpander.Visibility = Visibility.Collapsed; // TEMP: Disable custom filters
-            Grid.SetRow(categoryExpander, 7);
+            Grid.SetRow(categoryExpander, 8);
             grid.Children.Add(categoryExpander);
 
             return grid;
@@ -741,6 +783,79 @@ namespace ApolloSync
         #endregion
 
         #region Search
+
+        private ToggleButton CreateCombinationModeButton(string content, string tooltip, PresetTagCombinationMode mode)
+        {
+            var button = new ToggleButton
+            {
+                Content = content,
+                Tag = mode,
+                ToolTip = tooltip,
+                Margin = new Thickness(0, 0, 4, 0),
+                Padding = new Thickness(8, 2, 8, 2),
+                MinWidth = 72
+            };
+            button.Click += CombinationModeButton_Click;
+            return button;
+        }
+
+        private void CombinationModeButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (!(sender is ToggleButton clickedButton) ||
+                !(clickedButton.Tag is PresetTagCombinationMode mode) ||
+                !(DataContext is ApolloSyncSettingsViewModel vm))
+            {
+                return;
+            }
+
+            vm.Settings.PresetTagCombinationMode = mode;
+            UpdatePresetTagCombinationUi();
+        }
+
+        private void UpdatePresetTagCombinationUi()
+        {
+            var mode = PresetTagCombinationMode.Or;
+            if (DataContext is ApolloSyncSettingsViewModel vm)
+            {
+                mode = vm.Settings.PresetTagCombinationMode;
+            }
+
+            if (_filtersHelpText != null)
+            {
+                string helpKey;
+                switch (mode)
+                {
+                    case PresetTagCombinationMode.And:
+                        helpKey = "LOC_ApolloSync_Settings_Filters_Help_And";
+                        break;
+                    case PresetTagCombinationMode.Not:
+                        helpKey = "LOC_ApolloSync_Settings_Filters_Help_Not";
+                        break;
+                    default:
+                        helpKey = "LOC_ApolloSync_Settings_Filters_Help_Or";
+                        break;
+                }
+
+                _filtersHelpText.Text = ResourceProvider.GetString(helpKey).TrimEnd()
+                    + " "
+                    + ResourceProvider.GetString("LOC_ApolloSync_Settings_Filters_Help_CreatePresets").TrimStart();
+            }
+
+            if (_combinationOrButton != null)
+            {
+                _combinationOrButton.IsChecked = mode == PresetTagCombinationMode.Or;
+            }
+
+            if (_combinationAndButton != null)
+            {
+                _combinationAndButton.IsChecked = mode == PresetTagCombinationMode.And;
+            }
+
+            if (_combinationNotButton != null)
+            {
+                _combinationNotButton.IsChecked = mode == PresetTagCombinationMode.Not;
+            }
+        }
 
         private void FilterSearch_TextChanged(object sender, TextChangedEventArgs e)
         {


### PR DESCRIPTION
## Summary

Adds support for syncing by tags (in addition to the existing Presets). Also added a search box that lets you filter the Presets/Tags checkbox areas, and a checkbox to only show checked boxes. 

With this, it became obvious with a large library that this could get out of control, so I also added a setting for users to choose how filter presets and tags combine, with localized help text and tooltips that update per mode:
- `OR` (by default) - games will sync if they match _any_ selected preset **or** _any_ selected tag
- `AND` - require at least one matching preset (if any) and at least one matching tag (if any) to sync. Use case in mind: controller-only sync, etc.
- `NOT` - treat tags as exclusions. Not sure whether this has a real use case, but it was simple enough and didn't bloat the UI any further. The closest conceptual ideas I can think of only work if you have negative tags `AND` exclusions (i.e. "does not have controller tag" as a tag), which then would fall into the `AND` category anyway. I suppose someone might want to filter out single-player games or something?

Also fixes a sync bug where unchecking presets/tags did not remove previously exported games from `apps.json`.

Also includes machine-translated associated localization strings.

<img width="912" height="855" alt="image" src="https://github.com/user-attachments/assets/5b734c24-352e-40b0-85a2-9920fd0cbe17" />

### Bug fix

- **Prune on filter change** — Sync always runs removal before add/update. Unchecking presets or tags (including clearing all filters) removes extension-managed, non-pinned entries from `apps.json` on the next sync. Non-extension entries are untouched.

### Files changed

| Area | Files |
|------|--------|
| Sync logic | `ApolloSync.cs` |
| Settings model | `Settings/ApolloSyncSettings.cs` |
| Settings UI | `Settings/ApolloSyncSettingsView.xaml.cs` |
| Localization | `Localization/*.xaml` (19 locales) |

5 commits on `tags-and-search` since `origin/master` (v1.2.1).