### PR TITLE
Address July 2026 audit findings

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -46,6 +46,11 @@ jobs:
 
           # Bump extension.yaml
           yq -i ".Version = \"${version}\"" extension.yaml
+
+          # Bump the assembly version so shipped DLLs report the real version in logs
+          # and crash reports. Assembly versions are 4-part.
+          sed -i -E "s/^\[assembly: AssemblyVersion\(\".*\"\)\]/[assembly: AssemblyVersion(\"${version}.0\")]/" Properties/AssemblyInfo.cs
+          sed -i -E "s/^\[assembly: AssemblyFileVersion\(\".*\"\)\]/[assembly: AssemblyFileVersion(\"${version}.0\")]/" Properties/AssemblyInfo.cs
 
           # Prepend new package entry to manifest.yaml
           VERSION="$version" \
@@ -77,7 +82,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           git checkout -b "$branch"
-          git add extension.yaml manifest.yaml
+          git add extension.yaml manifest.yaml Properties/AssemblyInfo.cs
           git commit -m "Bump version to ${version}"
           git push -u origin "$branch"
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,11 +12,16 @@ on:
 
 jobs:
   claude:
+    # github.actor gates every trigger on the user who caused the event, so an
+    # untrusted account cannot spend CLAUDE_CODE_OAUTH_TOKEN by opening an issue
+    # or comment containing '@claude'. Matches claude-code-review.yml.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      github.actor == 'sharkusmanch' && (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -26,7 +31,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,7 +7,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Validate version consistency
         run: |
@@ -37,6 +37,23 @@ jobs:
             errors=$((errors + 1))
           fi
 
+          # The assembly version is what shows up in Playnite logs and crash reports,
+          # so it must track extension.yaml. Assembly versions are 4-part.
+          assembly_version=$(grep -oP '^\[assembly: AssemblyVersion\("\K[^"]+' Properties/AssemblyInfo.cs)
+          assembly_file_version=$(grep -oP '^\[assembly: AssemblyFileVersion\("\K[^"]+' Properties/AssemblyInfo.cs)
+
+          echo "AssemblyInfo version:   $assembly_version"
+
+          if [ "$assembly_version" != "${ext_version}.0" ]; then
+            echo "::error::AssemblyVersion ($assembly_version) does not match extension.yaml (expected ${ext_version}.0)"
+            errors=$((errors + 1))
+          fi
+
+          if [ "$assembly_file_version" != "${ext_version}.0" ]; then
+            echo "::error::AssemblyFileVersion ($assembly_file_version) does not match extension.yaml (expected ${ext_version}.0)"
+            errors=$((errors + 1))
+          fi
+
           if [ $errors -gt 0 ]; then
             exit 1
           fi
@@ -46,26 +63,18 @@ jobs:
   build:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - uses: robinraju/release-downloader@v1.8
-        id: download_playnite
-        with:
-          repository: "JosefNemec/Playnite"
-          latest: true
-          tarBall: false
-          zipBall: false
-          fileName: "Playnite*.zip"
-          out-file-path: ${{ runner.temp }}/playnite
-          extract: true
-
+      # No Playnite download here: only the release job needs Toolbox.exe to pack the
+      # .pext. The glob also asked for "Playnite*.zip", which current Playnite releases
+      # do not publish.
       - run: |
           dotnet build ApolloSync.csproj -c Release
 
   test:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - run: |
           dotnet test Tests/ApolloSync.Tests.csproj

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Validate version consistency
         run: |
@@ -44,13 +44,24 @@ jobs:
 
           echo "All validations passed."
 
-  build:
+  test:
     needs: validate
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - uses: robinraju/release-downloader@v1.8
+      - run: |
+          dotnet test Tests/ApolloSync.Tests.csproj
+
+  build:
+    # Gate on tests: this workflow is workflow_dispatch only, so without this a release
+    # can ship from a commit the test suite never ran against.
+    needs: [validate, test]
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: robinraju/release-downloader@v1.13
         id: download_playnite
         with:
           repository: "JosefNemec/Playnite"
@@ -67,7 +78,7 @@ jobs:
           dotnet build ApolloSync.csproj -c Release
           ${{ runner.temp }}/playnite/Toolbox.exe pack bin/Release/net462/ dist
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: artifacts
           path: |
@@ -81,16 +92,16 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
+      # Uses the runner's preinstalled yq rather than mikefarah/yq@master: a floating
+      # branch ref is not a safe pin for a workflow with contents: write.
       - name: Get Version
         id: version
-        uses: mikefarah/yq@master
-        with:
-          cmd: yq '.Version' extension.yaml
+        run: echo "result=$(yq '.Version' extension.yaml)" >> "$GITHUB_OUTPUT"
 
       - name: Pull artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: artifacts
 

--- a/ApolloSync.cs
+++ b/ApolloSync.cs
@@ -942,6 +942,8 @@ namespace ApolloSync
                 var successCount = 0;
                 var failureCount = 0;
                 var errors = new List<string>();
+                // Manual-removal records to clear, applied only once the write to disk succeeds.
+                var exportedGameIds = new List<Guid>();
 
                 lock (_configLock)
                 {
@@ -964,9 +966,7 @@ namespace ApolloSync
                                 if (TryAddOrUpdateAppBatch(game, config))
                                 {
                                     successCount++;
-                                    // An explicit export overrides an earlier explicit removal,
-                                    // otherwise the next sync would strip the game straight back out.
-                                    _managedStore.ClearManualRemoval(game.Id);
+                                    exportedGameIds.Add(game.Id);
                                     logger.Debug($"Successfully processed: {game.Name}");
                                 }
                                 else
@@ -993,6 +993,17 @@ namespace ApolloSync
                             try
                             {
                                 SaveAppsConfig(config);
+
+                                // Only now drop the manual-removal records. An explicit export
+                                // overrides an explicit removal, but if the write above failed
+                                // the export did not happen — clearing before the save would
+                                // strip the protection for the rest of the session and let the
+                                // next cover-image change or sync silently re-add the game.
+                                foreach (var exportedId in exportedGameIds)
+                                {
+                                    _managedStore.ClearManualRemoval(exportedId);
+                                }
+
                                 SaveManagedStore();
                                 logger.Info("Batch export save completed successfully");
                             }

--- a/ApolloSync.cs
+++ b/ApolloSync.cs
@@ -712,8 +712,10 @@ namespace ApolloSync
 
         #region User Operations with Feedback
         private volatile int _syncRunning;
-        private CancellationTokenSource _syncCts;
-        private Task _syncTask;
+        private volatile CancellationTokenSource _syncCts;
+        // volatile: read by callers on other threads that must observe the current sync's task,
+        // not a stale one. See SyncFilteredGamesWithProgress for why it is published early.
+        private volatile Task _syncTask;
 
         private void SyncFilteredGamesWithProgress()
         {
@@ -725,9 +727,17 @@ namespace ApolloSync
             }
 
             var cts = new CancellationTokenSource();
+
+            // Publish _syncTask and _syncCts BEFORE dispatching the work. Assigning
+            // "_syncTask = Task.Run(...)" would publish the field only after the body had already
+            // been queued, so a caller doing CancelSync() + _syncTask.Wait() could observe a null
+            // or already-completed task while this sync was mid-flight, skip the wait, and have
+            // its changes overwritten when the sync saved its own stale snapshot.
+            var completion = new TaskCompletionSource<bool>();
+            _syncTask = completion.Task;
             _syncCts = cts;
 
-            _syncTask = Task.Run(() =>
+            Task.Run(() =>
             {
                 try
                 {
@@ -738,6 +748,8 @@ namespace ApolloSync
                     _syncCts = null;
                     cts.Dispose();
                     Interlocked.Exchange(ref _syncRunning, 0);
+                    // Signalled last: waiters must not resume until the sync's final save is done.
+                    completion.SetResult(true);
                 }
             });
         }

--- a/ApolloSync.cs
+++ b/ApolloSync.cs
@@ -70,22 +70,15 @@ namespace ApolloSync
             }
         }
 
-        private bool IsGameManuallyRemoved(Game game, JObject config)
+        private bool IsGameManuallyRemoved(Game game)
         {
-            // Manual removal means: it WAS managed but its entry is now missing from apps.json.
-            // With identity UUIDs, presence is determined by uuid == game.Id.
-            var apps = (JArray)(config["apps"] ?? new JArray());
-            var presentInConfig = apps
-                .OfType<JObject>()
-                .Select(a => (string)a["uuid"])
-                .Where(s => !string.IsNullOrEmpty(s) && Guid.TryParse(s, out _))
-                .Any(s => Guid.Parse(s) == game.Id);
-
-            var isManaged = _managedStore.GameToUuid.ContainsKey(game.Id);
-
-            if (isManaged && !presentInConfig)
+            // Read the explicit record written by RemoveGamesWithFeedback / RemoveGamesFromManaged.
+            // This used to be inferred from "managed but missing from apps.json", but
+            // SyncManagedStore() prunes exactly those entries on startup, so the inference always
+            // returned false after a restart and manually removed games were silently re-added.
+            if (_managedStore.IsManuallyRemoved(game.Id))
             {
-                logger.Debug($"Game {game.Name} appears to be manually removed (was managed but missing from apps.json)");
+                logger.Debug($"Game {game.Name} was manually removed from Apollo management");
                 return true;
             }
 
@@ -329,9 +322,10 @@ namespace ApolloSync
             _managedStore = new ManagedStore
             {
                 GameToUuid = new System.Collections.Concurrent.ConcurrentDictionary<Guid, Guid>(
-                    _settings.Settings.ManagedGameMappings ?? new Dictionary<Guid, Guid>())
+                    _settings.Settings.ManagedGameMappings ?? new Dictionary<Guid, Guid>()),
             };
-            logger.Debug($"Loaded managed store from settings with {_managedStore.GameToUuid.Count} entries");
+            _managedStore.ResetManuallyRemoved(_settings.Settings.ManuallyRemovedGames);
+            logger.Debug($"Loaded managed store from settings with {_managedStore.GameToUuid.Count} entries and {_managedStore.ManuallyRemovedCount} manually removed games");
         }
 
         public List<Game> GetManagedGamesForSettings()
@@ -373,17 +367,79 @@ namespace ApolloSync
             {
                 if (_managedStore?.GameToUuid == null) return;
 
+                // Same lost-update guard as ExportGamesWithFeedback / RemoveGamesWithFeedback.
+                // A background sync loads apps.json, works outside the lock, then saves its own
+                // snapshot — without cancelling it first, that stale snapshot would write the
+                // entries we are about to delete straight back into apps.json, orphaned from
+                // the store. Must not run on the UI thread: SaveAppsConfig can dispatch a
+                // permission prompt back to it while we hold _configLock.
+                CancelSync();
+                try
+                {
+                    var syncCompleted = _syncTask?.Wait(TimeSpan.FromSeconds(30)) ?? true;
+                    if (!syncCompleted)
+                        logger.Warn("Previous sync task did not finish within 30 s; proceeding with removal anyway");
+                }
+                catch (AggregateException) { }
+
                 lock (_configLock)
                 {
-                    foreach (var gameId in gameIds)
+                    // Dropping the store entry alone would leave the app entry stranded in
+                    // apps.json with nothing tracking it, so remove from both sides.
+                    var config = LoadAppsConfig();
+                    if (config == null)
                     {
-                        Guid removed;
-                        _managedStore.GameToUuid.TryRemove(gameId, out removed);
+                        logger.Error("Cannot remove games from managed store - failed to load apps.json");
+                        return;
                     }
 
+                    var apps = (JArray)(config["apps"] ?? new JArray());
+
+                    foreach (var gameId in gameIds)
+                    {
+                        // Capture before removal: only a game we actually managed should be
+                        // blacklisted from future syncs.
+                        var wasManaged = _managedStore.GameToUuid.ContainsKey(gameId);
+
+                        var game = PlayniteApi.Database.Games.Get(gameId);
+                        if (game != null)
+                        {
+                            syncService.Remove(config, _managedStore, game);
+                        }
+                        else
+                        {
+                            // Game is gone from the library; drop its entry by the stored UUID.
+                            Guid uuid;
+                            if (_managedStore.GameToUuid.TryGetValue(gameId, out uuid))
+                            {
+                                for (int i = apps.Count - 1; i >= 0; i--)
+                                {
+                                    var obj = apps[i] as JObject;
+                                    Guid appUuid;
+                                    if (obj != null && Guid.TryParse((string)obj["uuid"], out appUuid) && appUuid == uuid)
+                                    {
+                                        apps.RemoveAt(i);
+                                    }
+                                }
+                            }
+
+                            Guid removed;
+                            _managedStore.GameToUuid.TryRemove(gameId, out removed);
+                        }
+
+                        if (wasManaged)
+                        {
+                            // Explicit user action — do not let the next sync re-add it.
+                            _managedStore.MarkManuallyRemoved(gameId);
+                        }
+                    }
+
+                    // Order matters: if the apps.json write fails it throws, SaveManagedStore is
+                    // skipped, and the on-disk store still matches the unchanged apps.json.
+                    SaveAppsConfig(config);
                     SaveManagedStore();
                 }
-                logger.Info($"Removed {gameIds.Count} games from managed store");
+                logger.Info($"Removed {gameIds.Count} games from managed store and apps.json");
             }
             catch (Exception ex)
             {
@@ -395,8 +451,9 @@ namespace ApolloSync
         {
             // Save managed store to plugin settings instead of separate file
             _settings.Settings.ManagedGameMappings = new Dictionary<Guid, Guid>(_managedStore.GameToUuid);
+            _settings.Settings.ManuallyRemovedGames = _managedStore.ManuallyRemovedSnapshot();
             SavePluginSettings(_settings.Settings);
-            logger.Debug($"Saved managed store to settings with {_managedStore.GameToUuid.Count} entries");
+            logger.Debug($"Saved managed store to settings with {_managedStore.GameToUuid.Count} entries and {_managedStore.ManuallyRemovedCount} manually removed games");
         }
 
         private void SyncManagedStore()
@@ -425,17 +482,29 @@ namespace ApolloSync
                     }
                 }
 
-                // Find managed store entries that don't exist in apps.json
+                // Find managed store entries that don't exist in apps.json. Note this deliberately
+                // does not touch ManuallyRemoved — those games are absent from apps.json by
+                // definition, and pruning them here is what previously killed the feature.
                 var toRemove = _managedStore.GameToUuid.Where(kvp => !configUuids.Contains(kvp.Value)).ToList();
 
-                if (toRemove.Count > 0)
+                // Drop manual-removal records for games that no longer exist in the library, so
+                // the set cannot grow without bound.
+                var staleManualRemovals = _managedStore.ManuallyRemovedSnapshot()
+                    .Where(id => PlayniteApi.Database.Games.Get(id) == null)
+                    .ToList();
+
+                if (toRemove.Count > 0 || staleManualRemovals.Count > 0)
                 {
-                    logger.Info($"Syncing managed store: removing {toRemove.Count} orphaned entries");
+                    logger.Info($"Syncing managed store: removing {toRemove.Count} orphaned entries and {staleManualRemovals.Count} stale manual-removal records");
                     foreach (var kvp in toRemove)
                     {
                         logger.Debug($"Removing orphaned managed store entry: Game {kvp.Key} -> UUID {kvp.Value}");
                         Guid removedUuid;
                         _managedStore.GameToUuid.TryRemove(kvp.Key, out removedUuid);
+                    }
+                    foreach (var id in staleManualRemovals)
+                    {
+                        _managedStore.ClearManualRemoval(id);
                     }
                     SaveManagedStore();
                     logger.Info("Managed store sync completed");
@@ -495,6 +564,20 @@ namespace ApolloSync
 
         private bool GameMeetsCurrentFilters(Game game)
         {
+            bool evaluationFailed;
+            return GameMeetsCurrentFilters(game, out evaluationFailed);
+        }
+
+        /// <summary>
+        /// Evaluates the game against the selected filter presets (OR logic).
+        /// <paramref name="evaluationFailed"/> is set when a preset could not be evaluated at all,
+        /// which is not the same as "did not match" — callers that delete on a false result must
+        /// check it, or one transient failure wipes every non-pinned managed entry.
+        /// </summary>
+        private bool GameMeetsCurrentFilters(Game game, out bool evaluationFailed)
+        {
+            evaluationFailed = false;
+
             // Use filter presets with OR logic - game matches if it matches ANY selected preset
             if (_settings.Settings.IncludedFilterPresetIds?.Count > 0)
             {
@@ -514,6 +597,7 @@ namespace ApolloSync
                         }
                         catch (Exception ex)
                         {
+                            evaluationFailed = true;
                             logger.Error(ex, $"Failed to check game against filter preset: {filterPreset.Name}");
                         }
                     }
@@ -524,6 +608,31 @@ namespace ApolloSync
             return false;
 
 
+        }
+
+        /// <summary>
+        /// Decides whether a managed game should be dropped from apps.json. Kept pure — no
+        /// Playnite database access — so the removal rules are directly testable.
+        /// </summary>
+        internal static bool ShouldRemoveManagedGame(bool gameExistsInLibrary, bool isPinned, bool meetsFilters, bool filterEvaluationFailed)
+        {
+            if (!gameExistsInLibrary)
+            {
+                return true;
+            }
+
+            if (isPinned)
+            {
+                return false;
+            }
+
+            // "Could not determine" must never be read as "does not match".
+            if (filterEvaluationFailed)
+            {
+                return false;
+            }
+
+            return !meetsFilters;
         }
 
         private int RemoveFilteredOutGames(JObject config, HashSet<Guid> pinnedGameIds = null)
@@ -545,42 +654,34 @@ namespace ApolloSync
 
                     // Get the game from database
                     var game = PlayniteApi.Database.Games.Get(gameId);
-                    if (game == null)
-                    {
-                        // Game no longer exists in database, remove it
-                        logger.Info($"Removing game {gameId} - no longer exists in database");
-                        managedGamesToRemove.Add(gameId);
 
-                        // Find and mark app for removal
-                        var appToRemove = apps.OfType<JObject>().FirstOrDefault(app =>
-                            Guid.TryParse((string)app["uuid"], out var uuid) && uuid == appUuid);
-                        if (appToRemove != null)
+                    var meetsFilters = false;
+                    var filterEvaluationFailed = false;
+                    if (game != null)
+                    {
+                        meetsFilters = GameMeetsCurrentFilters(game, out filterEvaluationFailed);
+                    }
+
+                    if (!ShouldRemoveManagedGame(game != null, pinned.Contains(gameId), meetsFilters, filterEvaluationFailed))
+                    {
+                        if (filterEvaluationFailed)
                         {
-                            appsToRemove.Add(appToRemove);
+                            logger.Warn($"Keeping game {game.Name} - filter presets could not be evaluated, so no removal decision can be made");
                         }
                         continue;
                     }
 
-                    // Check if game is pinned
-                    if (pinned.Contains(gameId))
-                    {
-                        logger.Debug($"Game {game.Name} is pinned, keeping in apps.json even if it doesn't meet filters");
-                        continue;
-                    }
+                    logger.Info(game == null
+                        ? $"Removing game {gameId} - no longer exists in database"
+                        : $"Removing game {game.Name} - no longer meets filters (not pinned)");
+                    managedGamesToRemove.Add(gameId);
 
-                    // Check if game still meets current filters
-                    if (!GameMeetsCurrentFilters(game))
+                    // Find and mark app for removal
+                    var appToRemove = apps.OfType<JObject>().FirstOrDefault(app =>
+                        Guid.TryParse((string)app["uuid"], out var uuid) && uuid == appUuid);
+                    if (appToRemove != null)
                     {
-                        logger.Info($"Removing game {game.Name} - no longer meets filters (not pinned)");
-                        managedGamesToRemove.Add(gameId);
-
-                        // Find and mark app for removal
-                        var appToRemove = apps.OfType<JObject>().FirstOrDefault(app =>
-                            Guid.TryParse((string)app["uuid"], out var uuid) && uuid == appUuid);
-                        if (appToRemove != null)
-                        {
-                            appsToRemove.Add(appToRemove);
-                        }
+                        appsToRemove.Add(appToRemove);
                     }
                 }
 
@@ -709,7 +810,7 @@ namespace ApolloSync
                 try
                 {
                     // Check if this game was manually removed and should not be re-added
-                    if (IsGameManuallyRemoved(game, config))
+                    if (IsGameManuallyRemoved(game))
                     {
                         logger.Info($"Skipping game {game.Name} - appears to have been manually removed from Apollo management");
                         continue;
@@ -863,6 +964,9 @@ namespace ApolloSync
                                 if (TryAddOrUpdateAppBatch(game, config))
                                 {
                                     successCount++;
+                                    // An explicit export overrides an earlier explicit removal,
+                                    // otherwise the next sync would strip the game straight back out.
+                                    _managedStore.ClearManualRemoval(game.Id);
                                     logger.Debug($"Successfully processed: {game.Name}");
                                 }
                                 else
@@ -966,10 +1070,20 @@ namespace ApolloSync
 
                             try
                             {
+                                // SyncService.Remove reports success even when the game was never
+                                // in apps.json, so check ownership first. Without this, removing a
+                                // never-exported game would blacklist it from all future syncs.
+                                var wasManaged = _managedStore.GameToUuid.ContainsKey(game.Id);
+
                                 // Use batch operation that doesn't save to disk
                                 if (TryRemoveAppBatch(game, config))
                                 {
                                     successCount++;
+                                    if (wasManaged)
+                                    {
+                                        // Record the intent explicitly so the next sync does not re-add it.
+                                        _managedStore.MarkManuallyRemoved(game.Id);
+                                    }
                                     logger.Debug($"Successfully processed removal: {game.Name}");
                                 }
                                 else
@@ -1118,6 +1232,15 @@ namespace ApolloSync
             }
 
             logger.Debug($"TryAddOrUpdateApp called for game: {game.Name} (ID: {game.Id})");
+
+            // Automatic triggers (install, cover-image change) must not undo an explicit removal.
+            // Explicit re-export goes through TryAddOrUpdateAppBatch, which clears the record
+            // first, so this guard does not block the user from deliberately re-adding a game.
+            if (IsGameManuallyRemoved(game))
+            {
+                logger.Debug($"Skipping automatic add/update for {game.Name} - manually removed from Apollo management");
+                return false;
+            }
 
             try
             {
@@ -1305,7 +1428,11 @@ namespace ApolloSync
             }
             catch (Exception ex)
             {
+                // Must propagate. Callers only skip SaveManagedStore() — and so avoid recording
+                // ownership that disagrees with what actually reached apps.json — if they see
+                // the failure. Swallowing it here made every caller's catch unreachable.
                 logger.Error(ex, $"Exception occurred while saving apps config");
+                throw;
             }
         }
 
@@ -1320,9 +1447,15 @@ namespace ApolloSync
                     throw new ArgumentException($"Permission fix is only supported for local paths; got: {filePath}");
                 }
 
+                // Grant to the invoking user's SID only. Granting BUILTIN\Users (S-1-5-32-545)
+                // would let any unprivileged local account rewrite apps.json, whose "cmd" values
+                // the Apollo/Sunshine service executes — a local privilege-escalation path.
+                var userSid = System.Security.Principal.WindowsIdentity.GetCurrent().User.Value;
+
                 // Write the icacls invocation to a temp script that receives the file path as
-                // $args[0]. PowerShell passes positional arguments verbatim — no shell
-                // interpretation of special characters — so filePath cannot inject commands.
+                // $args[0] and the SID as $args[1]. PowerShell passes positional arguments
+                // verbatim — no shell interpretation of special characters — so neither
+                // filePath nor the SID can inject commands.
                 var scriptPath = Path.Combine(
                     Path.GetTempPath(),
                     "apollosync_perms_" + Path.GetRandomFileName() + ".ps1");
@@ -1331,15 +1464,16 @@ namespace ApolloSync
                     using (var fs = new FileStream(scriptPath, FileMode.CreateNew, FileAccess.Write, FileShare.None))
                     using (var w = new StreamWriter(fs, new UTF8Encoding(false)))
                     {
-                        w.Write("icacls $args[0] /grant '*S-1-5-32-545:(M)'");
+                        w.Write("icacls $args[0] /grant ('*' + $args[1] + ':(M)')");
                     }
 
                     var psi = new System.Diagnostics.ProcessStartInfo
                     {
                         FileName = "powershell.exe",
                         // Both scriptPath and filePath are local absolute paths; Windows filenames
-                        // cannot contain double quotes, so quoting here is safe.
-                        Arguments = $"-NoProfile -NonInteractive -ExecutionPolicy Bypass -File \"{scriptPath}\" \"{filePath}\"",
+                        // cannot contain double quotes, so quoting here is safe. The SID comes from
+                        // WindowsIdentity and is alphanumeric with hyphens.
+                        Arguments = $"-NoProfile -NonInteractive -ExecutionPolicy Bypass -File \"{scriptPath}\" \"{filePath}\" \"{userSid}\"",
                         Verb = "runas",
                         UseShellExecute = true,
                         CreateNoWindow = true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,8 @@ Strong success criteria let you loop independently. Weak criteria ("make it work
 This project targets **.NET Framework 4.6.2**. C# 8+ features (nullable reference types, switch expressions, using declarations) are not available.
 
 **Build**
-- Use `MSBuild.exe` (Visual Studio / VS Build Tools), not `dotnet build`. The `dotnet` CLI does not generate `.g.cs` XAML code-behind files for WPF on .NET Framework — the build will succeed but the view won't work.
+- Use `dotnet build ApolloSync.csproj -c Release`. This is what CI runs. It does generate the XAML `.g.cs` code-behind (verified: `obj/Release/net462/Settings/ApolloSyncSettingsView.g.cs` is produced on a clean build with the .NET 8 SDK).
+- A previous version of this file mandated `MSBuild.exe` on the grounds that `dotnet build` skips WPF XAML codegen on .NET Framework. That is not true here. `MSBuild.exe` from a **Build Tools**-only install additionally fails to resolve `Microsoft.NET.Sdk.WindowsDesktop` unless the managed desktop workload is present.
 - This project uses **SDK-style `.csproj`** (`Microsoft.NET.Sdk.WindowsDesktop`). New `.cs` files are auto-included by default. Do not add `<Compile Include>` entries manually.
 - When adding NuGet packages, only use versions that ship a `net462` (or `net461`/`net45`) target folder. Don't rely on `netstandard2.0` fallbacks — they can silently break at runtime inside Playnite's AppDomain.
 
@@ -145,15 +146,22 @@ This project targets **.NET Framework 4.6.2**. C# 8+ features (nullable referenc
 - `Game.Platforms`, `Game.Genres`, `Game.Tags`, etc. are `List<T>` — check for `null` before iterating; they're not initialized to empty lists by default.
 
 **ManagedStore (plugin-specific state)**
-- `ManagedStore` (UUID map + manually removed set) is custom state that lives outside Playnite's database — it must be explicitly serialized/deserialized and kept in sync with `apps.json`.
+- `ManagedStore` holds two things: `GameToUuid` (the UUID map) and `ManuallyRemoved` (games the user explicitly removed). Both live outside Playnite's database and are persisted by projecting them into plugin settings in `SaveManagedStore()`.
 - When modifying sync logic, verify the store roundtrips correctly (write → reload → compare).
 - The store and `apps.json` can diverge if a sync is interrupted; treat them as potentially inconsistent and reconcile defensively.
 - UUID mapping is bidirectional: adding a game must write the entry to `apps.json` AND add to `store.GameToUuid`; removing must do both. Partial updates cause divergence.
+- `ManuallyRemoved` must be recorded explicitly at the point of user action. Do not infer it from "in the store but missing from `apps.json`" — `SyncManagedStore()` prunes exactly those entries on startup, so the inference is always false after a restart.
 
 **apps.json invariants**
 - UUIDs in `apps.json` are always uppercase. `ConfigService` normalizes on load and save via `DeduplicateApps()`.
 - Duplicate UUIDs are resolved by keeping the entry with the highest `id` value — lower-id duplicates are silently discarded.
-- Writes use an atomic temp-file strategy: write to `%TEMP%` with `FileMode.CreateNew`, then `File.Copy` to the destination. Retry up to 3 times on `IOException`. Always delete the temp file in a `finally` block. Never write directly to `apps.json` in place.
+- Writes go through two strategies, in order:
+  - **Preferred** — temp file in the *destination directory*, `Flush(flushToDisk: true)`, then `File.Replace`. Atomic, and keeps the previous contents as `apps.json.bak`. Requires create rights in the destination directory.
+  - **Fallback** — write to `%TEMP%` with `FileMode.CreateNew`, then `File.Copy` over the destination, retrying up to 3 times on `IOException`. **Not atomic**: `File.Copy` truncates and rewrites in place, so a crash mid-copy is recoverable only from the backup.
+- **The default Program Files install always takes the fallback.** `TryFixFilePermissionsWithElevation` grants modify on the *file*, not the directory, so `File.Replace` can never create its temp file there. Do not describe the write as atomic in user-facing text.
+- The backup is taken exactly once, *before* the retry loop — taking it inside would let a later attempt copy a half-written destination over the only good copy. `BackupExistingFile` tries `<destination>.bak` first and falls back to `%LOCALAPPDATA%\ApolloSync\backups\` (with the destination path flattened into the file name) when the install directory isn't writable, so a backup exists even in the Program Files case.
+- Always delete the temp file in a `finally` block. Never write directly to `apps.json` in place.
+- `SaveAppsConfig` propagates write failures. Callers must not persist the managed store after a failed write, or the store will claim ownership that `apps.json` doesn't reflect.
 
 **Lock files and launch command**
 - Lock files are named `apollosync-{gameId:N}.lock` (format specifier `N` = no-hyphen GUID) and always live in `Path.GetTempPath()`. Different games get different lock paths.

--- a/Localization/cs_CZ.xaml
+++ b/Localization/cs_CZ.xaml
@@ -42,17 +42,8 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_InstallationStatus">Filtr stavu instalace</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames">Zahrnout nainstalované hry</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames_Help">Pokud je povoleno, budou pro export zvažovány pouze nainstalované hry.</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_IncludedPlatforms">Filtry platforem</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_IncludedPlatforms_Help">Vyberte platformy k zahrnutí do exportu. Pokud nejsou vybrány žádné, budou zahrnuty všechny platformy.</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_RequiredLabel">Filtr štítků</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_RequiredLabel_Help">Exportovat pouze hry s tímto štítkem. Ponechte prázdné pro export všech her.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_NoLabel">Štítek není vyžadován</sys:String>
     <sys:String x:Key="LOC_ApolloSync_DefaultLabel_Name">Apollo/Sunshine</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CreateDefaultLabel">Vytvořit výchozí štítek</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CompletionStatusFilter">Filtr stavu dokončení</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CompletionStatusFilter_Help">Vyberte stavy dokončení k zahrnutí do exportu. Pokud nejsou vybrány žádné, budou zahrnuty všechny stavy dokončení.</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CategoryFilter">Filtr kategorií</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CategoryFilter_Help">Vyberte kategorie k zahrnutí do exportu. Pokud nejsou vybrány žádné, budou zahrnuty všechny kategorie.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Předvolba filtru</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Použít předvolbu filtru Playnite</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Pokud je povoleno, bude místo jednotlivých filtrů níže použita vybraná předvolba filtru. Předvolby filtrů vytvořte v hlavním zobrazení knihovny Playnite.</sys:String>
@@ -80,5 +71,5 @@ Neúspěšné: {1}</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Message_Errors">Došlo k chybám</sys:String>
     <!-- New: Permission prompt for apps.json write -->
     <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Title">ApolloSync</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Body">ApolloSync potřebuje oprávnění k zápisu apps.json do Program Files. Povolit opravu oprávnění?</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Body">ApolloSync potřebuje oprávnění k zápisu apps.json do Program Files.&#10;&#10;Tím získá váš uživatelský účet Windows – a nikdo jiný – oprávnění tento soubor měnit. Windows požádá o schválení správcem. Změna je trvalá, dokud ji nevrátíte zpět.&#10;&#10;Povolit opravu oprávnění?</sys:String>
 </ResourceDictionary>

--- a/Localization/de_DE.xaml
+++ b/Localization/de_DE.xaml
@@ -42,17 +42,8 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_InstallationStatus">Installationsstatusfilter</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames">Installierte Spiele einschließen</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames_Help">Wenn aktiviert, werden nur installierte Spiele für den Export berücksichtigt.</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_IncludedPlatforms">Plattformfilter</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_IncludedPlatforms_Help">Wählen Sie Plattformen für den Export aus. Wenn keine ausgewählt sind, werden alle Plattformen einbezogen.</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_RequiredLabel">Label-Filter</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_RequiredLabel_Help">Nur Spiele mit diesem Label exportieren. Leer lassen, um alle Spiele zu exportieren.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_NoLabel">Kein Label erforderlich</sys:String>
     <sys:String x:Key="LOC_ApolloSync_DefaultLabel_Name">Apollo/Sunshine</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CreateDefaultLabel">Standard-Label erstellen</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CompletionStatusFilter">Abschlussstatusfilter</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CompletionStatusFilter_Help">Wählen Sie Abschlussstatus für den Export aus. Wenn keine ausgewählt sind, werden alle Abschlussstatus einbezogen.</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CategoryFilter">Kategoriefilter</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CategoryFilter_Help">Wählen Sie Kategorien für den Export aus. Wenn keine ausgewählt sind, werden alle Kategorien einbezogen.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Filtervoreinstellung</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Playnite-Filtervoreinstellung verwenden</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Wenn aktiviert, wird die ausgewählte Filtervoreinstellung anstelle der einzelnen Filter unten verwendet. Erstellen Sie Filtervoreinstellungen in der Hauptbibliotheksansicht von Playnite.</sys:String>
@@ -80,5 +71,5 @@ Fehlgeschlagen: {1}</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Message_Errors">Fehler aufgetreten</sys:String>
     <!-- New: Permission prompt for apps.json write -->
     <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Title">ApolloSync</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Body">ApolloSync benötigt die Berechtigung, apps.json in Programme zu schreiben. Berechtigungen korrigieren?</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Body">ApolloSync benötigt die Berechtigung, apps.json in Program Files zu schreiben.&#10;&#10;Dadurch erhält Ihr Windows-Benutzerkonto – und sonst niemand – die Berechtigung, diese Datei zu ändern. Windows fragt nach einer Bestätigung durch einen Administrator. Die Änderung bleibt bestehen, bis Sie sie rückgängig machen.&#10;&#10;Berechtigungen korrigieren?</sys:String>
 </ResourceDictionary>

--- a/Localization/en_US.xaml
+++ b/Localization/en_US.xaml
@@ -42,17 +42,8 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_InstallationStatus">Installation Status Filter</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames">Include installed games</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames_Help">When enabled, only installed games will be considered for export.</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_IncludedPlatforms">Platform Filters</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_IncludedPlatforms_Help">Select platforms to include in export. If none are selected, all platforms will be included.</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_RequiredLabel">Label Filter</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_RequiredLabel_Help">Only export games that have this label. Leave unselected to export all games.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_NoLabel">No label required</sys:String>
     <sys:String x:Key="LOC_ApolloSync_DefaultLabel_Name">Apollo/Sunshine</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CreateDefaultLabel">Create Default Label</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CompletionStatusFilter">Completion Status Filter</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CompletionStatusFilter_Help">Select completion statuses to include in export. If none are selected, all completion statuses will be included.</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CategoryFilter">Category Filter</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CategoryFilter_Help">Select categories to include in export. If none are selected, all categories will be included.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Filter Preset</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Use Playnite Filter Preset</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">When enabled, the selected filter preset will be used instead of the individual filters below. Create filter presets in Playnite's main library view.</sys:String>
@@ -80,5 +71,5 @@ Failed: {1}</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Message_Errors">Errors encountered</sys:String>
     <!-- New: Permission prompt for apps.json write -->
     <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Title">ApolloSync</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Body">ApolloSync needs permission to write apps.json in Program Files. Allow fixing permissions?</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Body">ApolloSync needs permission to write apps.json in Program Files.&#10;&#10;This grants your Windows user account — and no one else — permission to modify that file. Windows will ask for administrator approval. The change is permanent until you undo it.&#10;&#10;Allow fixing permissions?</sys:String>
 </ResourceDictionary>

--- a/Localization/es_ES.xaml
+++ b/Localization/es_ES.xaml
@@ -42,17 +42,8 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_InstallationStatus">Filtro de estado de instalación</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames">Incluir juegos instalados</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames_Help">Cuando está activado, solo se considerarán para exportar los juegos instalados.</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_IncludedPlatforms">Filtros de plataforma</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_IncludedPlatforms_Help">Selecciona las plataformas a incluir en la exportación. Si no se selecciona ninguna, se incluirán todas las plataformas.</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_RequiredLabel">Filtro de etiqueta</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_RequiredLabel_Help">Solo exportar juegos que tengan esta etiqueta. Déjalo sin seleccionar para exportar todos los juegos.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_NoLabel">Sin etiqueta requerida</sys:String>
     <sys:String x:Key="LOC_ApolloSync_DefaultLabel_Name">Apollo/Sunshine</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CreateDefaultLabel">Crear etiqueta predeterminada</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CompletionStatusFilter">Filtro de estado de finalización</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CompletionStatusFilter_Help">Selecciona los estados de finalización a incluir en la exportación. Si no se selecciona ninguno, se incluirán todos los estados.</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CategoryFilter">Filtro de categoría</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CategoryFilter_Help">Selecciona las categorías a incluir en la exportación. Si no se selecciona ninguna, se incluirán todas las categorías.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Preajuste de filtro</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Usar preajuste de filtro de Playnite</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Cuando está activado, se usará el preajuste de filtro seleccionado en lugar de los filtros individuales de abajo. Crea preajustes de filtro en la vista principal de la biblioteca de Playnite.</sys:String>
@@ -80,5 +71,5 @@ Fallidos: {1}</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Message_Errors">Se encontraron errores</sys:String>
     <!-- New: Permission prompt for apps.json write -->
     <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Title">ApolloSync</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Body">ApolloSync necesita permiso para escribir apps.json en Program Files. ¿Permitir corregir los permisos?</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Body">ApolloSync necesita permiso para escribir apps.json en Program Files.&#10;&#10;Esto concede a tu cuenta de usuario de Windows, y a nadie más, permiso para modificar ese archivo. Windows pedirá aprobación de administrador. El cambio es permanente hasta que lo deshagas.&#10;&#10;¿Permitir corregir los permisos?</sys:String>
 </ResourceDictionary>

--- a/Localization/fr_FR.xaml
+++ b/Localization/fr_FR.xaml
@@ -42,17 +42,8 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_InstallationStatus">Filtre d'état d'installation</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames">Inclure les jeux installés</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames_Help">Lorsque activé, seuls les jeux installés seront pris en compte pour l'exportation.</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_IncludedPlatforms">Filtres de plateforme</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_IncludedPlatforms_Help">Sélectionnez les plateformes à inclure dans l'exportation. Si aucune n'est sélectionnée, toutes les plateformes seront incluses.</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_RequiredLabel">Filtre d'étiquette</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_RequiredLabel_Help">Exporter uniquement les jeux ayant cette étiquette. Laissez non sélectionné pour exporter tous les jeux.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_NoLabel">Aucune étiquette requise</sys:String>
     <sys:String x:Key="LOC_ApolloSync_DefaultLabel_Name">Apollo/Sunshine</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CreateDefaultLabel">Créer l'étiquette par défaut</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CompletionStatusFilter">Filtre d'état de complétion</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CompletionStatusFilter_Help">Sélectionnez les états de complétion à inclure dans l'exportation. Si aucun n'est sélectionné, tous les états seront inclus.</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CategoryFilter">Filtre de catégorie</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CategoryFilter_Help">Sélectionnez les catégories à inclure dans l'exportation. Si aucune n'est sélectionnée, toutes les catégories seront incluses.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Préréglage de filtre</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Utiliser un préréglage de filtre Playnite</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Lorsque activé, le préréglage de filtre sélectionné sera utilisé à la place des filtres individuels ci-dessous. Créez des préréglages de filtre dans la vue principale de la bibliothèque Playnite.</sys:String>
@@ -80,5 +71,5 @@ Réussis : {0}
     <sys:String x:Key="LOC_ApolloSync_Message_Errors">Des erreurs ont été rencontrées</sys:String>
     <!-- New: Permission prompt for apps.json write -->
     <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Title">ApolloSync</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Body">ApolloSync a besoin de l'autorisation d'écrire apps.json dans Program Files. Autoriser la correction des permissions ?</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Body">ApolloSync a besoin de l'autorisation d'écrire apps.json dans Program Files.&#10;&#10;Cela accorde à votre compte d'utilisateur Windows, et à lui seul, l'autorisation de modifier ce fichier. Windows demandera une approbation administrateur. La modification est permanente jusqu'à ce que vous l'annuliez.&#10;&#10;Autoriser la correction des permissions ?</sys:String>
 </ResourceDictionary>

--- a/Localization/it_IT.xaml
+++ b/Localization/it_IT.xaml
@@ -42,17 +42,8 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_InstallationStatus">Filtro stato di installazione</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames">Includi giochi installati</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames_Help">Quando attivato, solo i giochi installati verranno considerati per l'esportazione.</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_IncludedPlatforms">Filtri piattaforma</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_IncludedPlatforms_Help">Seleziona le piattaforme da includere nell'esportazione. Se non ne viene selezionata nessuna, verranno incluse tutte le piattaforme.</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_RequiredLabel">Filtro etichetta</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_RequiredLabel_Help">Esporta solo i giochi con questa etichetta. Lascia non selezionato per esportare tutti i giochi.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_NoLabel">Nessuna etichetta richiesta</sys:String>
     <sys:String x:Key="LOC_ApolloSync_DefaultLabel_Name">Apollo/Sunshine</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CreateDefaultLabel">Crea etichetta predefinita</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CompletionStatusFilter">Filtro stato di completamento</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CompletionStatusFilter_Help">Seleziona gli stati di completamento da includere nell'esportazione. Se non ne viene selezionato nessuno, verranno inclusi tutti gli stati.</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CategoryFilter">Filtro categoria</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CategoryFilter_Help">Seleziona le categorie da includere nell'esportazione. Se non ne viene selezionata nessuna, verranno incluse tutte le categorie.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Preset filtro</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Usa preset filtro di Playnite</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Quando attivato, verrà utilizzato il preset filtro selezionato al posto dei filtri individuali sottostanti. Crea i preset filtro nella vista principale della libreria di Playnite.</sys:String>
@@ -80,5 +71,5 @@ Falliti: {1}</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Message_Errors">Errori riscontrati</sys:String>
     <!-- New: Permission prompt for apps.json write -->
     <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Title">ApolloSync</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Body">ApolloSync ha bisogno dell'autorizzazione per scrivere apps.json in Program Files. Consentire la correzione dei permessi?</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Body">ApolloSync ha bisogno dell'autorizzazione per scrivere apps.json in Program Files.&#10;&#10;Questo concede al tuo account utente Windows, e a nessun altro, l'autorizzazione di modificare quel file. Windows chiederà l'approvazione dell'amministratore. La modifica è permanente finché non la annulli.&#10;&#10;Consentire la correzione dei permessi?</sys:String>
 </ResourceDictionary>

--- a/Localization/ja_JP.xaml
+++ b/Localization/ja_JP.xaml
@@ -42,17 +42,8 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_InstallationStatus">インストール状態フィルター</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames">インストール済みゲームを含める</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames_Help">有効にすると、インストール済みのゲームのみがエクスポート対象になります。</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_IncludedPlatforms">プラットフォームフィルター</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_IncludedPlatforms_Help">エクスポートに含めるプラットフォームを選択します。未選択の場合、すべてのプラットフォームが含まれます。</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_RequiredLabel">ラベルフィルター</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_RequiredLabel_Help">このラベルが付いたゲームのみをエクスポートします。未選択の場合、すべてのゲームがエクスポートされます。</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_NoLabel">ラベル指定なし</sys:String>
     <sys:String x:Key="LOC_ApolloSync_DefaultLabel_Name">Apollo/Sunshine</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CreateDefaultLabel">既定のラベルを作成</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CompletionStatusFilter">クリア状況フィルター</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CompletionStatusFilter_Help">エクスポートに含めるクリア状況を選択します。未選択の場合、すべてのクリア状況が含まれます。</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CategoryFilter">カテゴリフィルター</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CategoryFilter_Help">エクスポートに含めるカテゴリを選択します。未選択の場合、すべてのカテゴリが含まれます。</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">フィルタープリセット</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Playniteのフィルタープリセットを使用</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">有効にすると、以下の個別フィルターの代わりに選択したフィルタープリセットが使用されます。フィルタープリセットはPlayniteのメインライブラリ画面で作成できます。</sys:String>
@@ -80,5 +71,5 @@
     <sys:String x:Key="LOC_ApolloSync_Message_Errors">エラーが発生しました</sys:String>
     <!-- New: Permission prompt for apps.json write -->
     <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Title">ApolloSync</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Body">ApolloSyncはProgram Files内のapps.jsonに書き込む権限が必要です。権限を修正しますか？</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Body">ApolloSyncはProgram Files内のapps.jsonに書き込む権限が必要です。&#10;&#10;この操作により、お使いのWindowsユーザーアカウントにのみ、このファイルを変更する権限が付与されます。Windowsが管理者の承認を求めます。この変更は、元に戻すまで永続的に有効です。&#10;&#10;権限を修正しますか？</sys:String>
 </ResourceDictionary>

--- a/Localization/ko_KR.xaml
+++ b/Localization/ko_KR.xaml
@@ -42,17 +42,8 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_InstallationStatus">설치 상태 필터</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames">설치된 게임 포함</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames_Help">활성화하면 설치된 게임만 내보내기 대상이 됩니다.</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_IncludedPlatforms">플랫폼 필터</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_IncludedPlatforms_Help">내보내기에 포함할 플랫폼을 선택합니다. 선택하지 않으면 모든 플랫폼이 포함됩니다.</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_RequiredLabel">라벨 필터</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_RequiredLabel_Help">이 라벨이 있는 게임만 내보냅니다. 선택하지 않으면 모든 게임이 내보내집니다.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_NoLabel">라벨 필요 없음</sys:String>
     <sys:String x:Key="LOC_ApolloSync_DefaultLabel_Name">Apollo/Sunshine</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CreateDefaultLabel">기본 라벨 만들기</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CompletionStatusFilter">완료 상태 필터</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CompletionStatusFilter_Help">내보내기에 포함할 완료 상태를 선택합니다. 선택하지 않으면 모든 완료 상태가 포함됩니다.</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CategoryFilter">카테고리 필터</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CategoryFilter_Help">내보내기에 포함할 카테고리를 선택합니다. 선택하지 않으면 모든 카테고리가 포함됩니다.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">필터 프리셋</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Playnite 필터 프리셋 사용</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">활성화하면 아래의 개별 필터 대신 선택한 필터 프리셋이 사용됩니다. 필터 프리셋은 Playnite의 메인 라이브러리 화면에서 만들 수 있습니다.</sys:String>
@@ -80,5 +71,5 @@
     <sys:String x:Key="LOC_ApolloSync_Message_Errors">오류가 발생했습니다</sys:String>
     <!-- New: Permission prompt for apps.json write -->
     <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Title">ApolloSync</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Body">ApolloSync에서 Program Files의 apps.json에 쓰기 권한이 필요합니다. 권한을 수정하시겠습니까?</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Body">ApolloSync에서 Program Files의 apps.json에 쓰기 권한이 필요합니다.&#10;&#10;이 작업은 사용자의 Windows 계정에만 해당 파일을 수정할 수 있는 권한을 부여합니다. Windows에서 관리자 승인을 요청합니다. 이 변경 사항은 직접 되돌리기 전까지 유지됩니다.&#10;&#10;권한을 수정하시겠습니까?</sys:String>
 </ResourceDictionary>

--- a/Localization/nl_NL.xaml
+++ b/Localization/nl_NL.xaml
@@ -42,17 +42,8 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_InstallationStatus">Installatiestatusfilter</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames">Geïnstalleerde games opnemen</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames_Help">Wanneer ingeschakeld, worden alleen geïnstalleerde games in aanmerking genomen voor export.</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_IncludedPlatforms">Platformfilters</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_IncludedPlatforms_Help">Selecteer platformen om op te nemen in de export. Als er geen zijn geselecteerd, worden alle platformen opgenomen.</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_RequiredLabel">Labelfilter</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_RequiredLabel_Help">Alleen games met dit label exporteren. Laat leeg om alle games te exporteren.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_NoLabel">Geen label vereist</sys:String>
     <sys:String x:Key="LOC_ApolloSync_DefaultLabel_Name">Apollo/Sunshine</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CreateDefaultLabel">Standaardlabel aanmaken</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CompletionStatusFilter">Voltooiingsstatusfilter</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CompletionStatusFilter_Help">Selecteer voltooiingsstatussen om op te nemen in de export. Als er geen zijn geselecteerd, worden alle voltooiingsstatussen opgenomen.</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CategoryFilter">Categoriefilter</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CategoryFilter_Help">Selecteer categorieën om op te nemen in de export. Als er geen zijn geselecteerd, worden alle categorieën opgenomen.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Filtervoorinstelling</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Playnite-filtervoorinstelling gebruiken</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Wanneer ingeschakeld, wordt de geselecteerde filtervoorinstelling gebruikt in plaats van de afzonderlijke filters hieronder. Maak filtervoorinstellingen aan in de hoofdbibliotheekweergave van Playnite.</sys:String>
@@ -80,5 +71,5 @@ Mislukt: {1}</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Message_Errors">Fouten opgetreden</sys:String>
     <!-- New: Permission prompt for apps.json write -->
     <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Title">ApolloSync</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Body">ApolloSync heeft toestemming nodig om apps.json in Program Files te schrijven. Machtigingen corrigeren?</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Body">ApolloSync heeft toestemming nodig om apps.json in Program Files te schrijven.&#10;&#10;Hiermee krijgt uw Windows-gebruikersaccount – en niemand anders – toestemming om dat bestand te wijzigen. Windows vraagt om goedkeuring van een beheerder. De wijziging blijft bestaan totdat u deze ongedaan maakt.&#10;&#10;Machtigingen corrigeren?</sys:String>
 </ResourceDictionary>

--- a/Localization/pl_PL.xaml
+++ b/Localization/pl_PL.xaml
@@ -42,17 +42,8 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_InstallationStatus">Filtr statusu instalacji</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames">Uwzględnij zainstalowane gry</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames_Help">Po włączeniu tylko zainstalowane gry będą brane pod uwagę przy eksporcie.</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_IncludedPlatforms">Filtry platform</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_IncludedPlatforms_Help">Wybierz platformy do uwzględnienia w eksporcie. Jeśli żadna nie jest wybrana, uwzględnione zostaną wszystkie platformy.</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_RequiredLabel">Filtr etykiet</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_RequiredLabel_Help">Eksportuj tylko gry z tą etykietą. Pozostaw puste, aby eksportować wszystkie gry.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_NoLabel">Etykieta nie jest wymagana</sys:String>
     <sys:String x:Key="LOC_ApolloSync_DefaultLabel_Name">Apollo/Sunshine</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CreateDefaultLabel">Utwórz domyślną etykietę</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CompletionStatusFilter">Filtr statusu ukończenia</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CompletionStatusFilter_Help">Wybierz statusy ukończenia do uwzględnienia w eksporcie. Jeśli żaden nie jest wybrany, uwzględnione zostaną wszystkie statusy ukończenia.</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CategoryFilter">Filtr kategorii</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CategoryFilter_Help">Wybierz kategorie do uwzględnienia w eksporcie. Jeśli żadna nie jest wybrana, uwzględnione zostaną wszystkie kategorie.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Szablon filtrów</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Użyj szablonu filtrów Playnite</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Po włączeniu wybrany szablon filtrów zostanie użyty zamiast poszczególnych filtrów poniżej. Twórz szablony filtrów w głównym widoku biblioteki Playnite.</sys:String>
@@ -80,5 +71,5 @@ Niepowodzenie: {1}</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Message_Errors">Wystąpiły błędy</sys:String>
     <!-- New: Permission prompt for apps.json write -->
     <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Title">ApolloSync</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Body">ApolloSync potrzebuje uprawnień do zapisu apps.json w Program Files. Czy naprawić uprawnienia?</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Body">ApolloSync potrzebuje uprawnień do zapisu apps.json w Program Files.&#10;&#10;Spowoduje to nadanie Twojemu kontu użytkownika Windows – i nikomu innemu – uprawnień do modyfikowania tego pliku. Windows poprosi o zgodę administratora. Zmiana jest trwała, dopóki jej nie cofniesz.&#10;&#10;Czy naprawić uprawnienia?</sys:String>
 </ResourceDictionary>

--- a/Localization/pt_BR.xaml
+++ b/Localization/pt_BR.xaml
@@ -42,17 +42,8 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_InstallationStatus">Filtro de status de instalação</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames">Incluir jogos instalados</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames_Help">Quando ativado, apenas jogos instalados serão considerados para exportação.</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_IncludedPlatforms">Filtros de plataforma</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_IncludedPlatforms_Help">Selecione as plataformas a incluir na exportação. Se nenhuma for selecionada, todas as plataformas serão incluídas.</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_RequiredLabel">Filtro de etiqueta</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_RequiredLabel_Help">Exportar apenas jogos com esta etiqueta. Deixe sem seleção para exportar todos os jogos.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_NoLabel">Nenhuma etiqueta necessária</sys:String>
     <sys:String x:Key="LOC_ApolloSync_DefaultLabel_Name">Apollo/Sunshine</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CreateDefaultLabel">Criar etiqueta padrão</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CompletionStatusFilter">Filtro de status de conclusão</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CompletionStatusFilter_Help">Selecione os status de conclusão a incluir na exportação. Se nenhum for selecionado, todos os status serão incluídos.</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CategoryFilter">Filtro de categoria</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CategoryFilter_Help">Selecione as categorias a incluir na exportação. Se nenhuma for selecionada, todas as categorias serão incluídas.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Predefinição de filtro</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Usar predefinição de filtro do Playnite</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Quando ativado, a predefinição de filtro selecionada será usada no lugar dos filtros individuais abaixo. Crie predefinições de filtro na visualização principal da biblioteca do Playnite.</sys:String>
@@ -80,5 +71,5 @@ Falhas: {1}</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Message_Errors">Erros encontrados</sys:String>
     <!-- New: Permission prompt for apps.json write -->
     <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Title">ApolloSync</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Body">O ApolloSync precisa de permissão para gravar o apps.json em Program Files. Permitir a correção das permissões?</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Body">O ApolloSync precisa de permissão para gravar o apps.json em Program Files.&#10;&#10;Isso concede à sua conta de usuário do Windows, e a mais ninguém, permissão para modificar esse arquivo. O Windows solicitará aprovação de administrador. A alteração é permanente até que você a desfaça.&#10;&#10;Permitir a correção das permissões?</sys:String>
 </ResourceDictionary>

--- a/Localization/pt_PT.xaml
+++ b/Localization/pt_PT.xaml
@@ -42,17 +42,8 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_InstallationStatus">Filtro de estado de instalação</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames">Incluir jogos instalados</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames_Help">Quando ativado, apenas os jogos instalados serão considerados para exportação.</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_IncludedPlatforms">Filtros de plataforma</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_IncludedPlatforms_Help">Selecione as plataformas a incluir na exportação. Se nenhuma for selecionada, todas as plataformas serão incluídas.</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_RequiredLabel">Filtro de etiqueta</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_RequiredLabel_Help">Exportar apenas jogos com esta etiqueta. Deixe sem seleção para exportar todos os jogos.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_NoLabel">Nenhuma etiqueta necessária</sys:String>
     <sys:String x:Key="LOC_ApolloSync_DefaultLabel_Name">Apollo/Sunshine</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CreateDefaultLabel">Criar etiqueta predefinida</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CompletionStatusFilter">Filtro de estado de conclusão</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CompletionStatusFilter_Help">Selecione os estados de conclusão a incluir na exportação. Se nenhum for selecionado, todos os estados serão incluídos.</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CategoryFilter">Filtro de categoria</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CategoryFilter_Help">Selecione as categorias a incluir na exportação. Se nenhuma for selecionada, todas as categorias serão incluídas.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Predefinição de filtro</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Usar predefinição de filtro do Playnite</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Quando ativado, a predefinição de filtro selecionada será utilizada em vez dos filtros individuais abaixo. Crie predefinições de filtro na vista principal da biblioteca do Playnite.</sys:String>
@@ -80,5 +71,5 @@ Falhados: {1}</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Message_Errors">Erros encontrados</sys:String>
     <!-- New: Permission prompt for apps.json write -->
     <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Title">ApolloSync</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Body">O ApolloSync necessita de permissão para escrever o apps.json em Program Files. Permitir a correção das permissões?</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Body">O ApolloSync necessita de permissão para escrever o apps.json em Program Files.&#10;&#10;Isto concede à sua conta de utilizador do Windows, e a mais ninguém, permissão para modificar esse ficheiro. O Windows irá pedir aprovação de administrador. A alteração é permanente até que a desfaça.&#10;&#10;Permitir a correção das permissões?</sys:String>
 </ResourceDictionary>

--- a/Localization/ro_RO.xaml
+++ b/Localization/ro_RO.xaml
@@ -42,17 +42,8 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_InstallationStatus">Filtru stare instalare</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames">Include jocurile instalate</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames_Help">Când este activat, doar jocurile instalate vor fi luate în considerare pentru export.</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_IncludedPlatforms">Filtre platformă</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_IncludedPlatforms_Help">Selectează platformele de inclus în export. Dacă nu este selectată niciuna, toate platformele vor fi incluse.</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_RequiredLabel">Filtru etichetă</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_RequiredLabel_Help">Exportă doar jocurile care au această etichetă. Lasă neselectat pentru a exporta toate jocurile.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_NoLabel">Nicio etichetă necesară</sys:String>
     <sys:String x:Key="LOC_ApolloSync_DefaultLabel_Name">Apollo/Sunshine</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CreateDefaultLabel">Creează etichetă implicită</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CompletionStatusFilter">Filtru stare finalizare</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CompletionStatusFilter_Help">Selectează stările de finalizare de inclus în export. Dacă nu este selectată niciuna, toate stările vor fi incluse.</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CategoryFilter">Filtru categorie</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CategoryFilter_Help">Selectează categoriile de inclus în export. Dacă nu este selectată niciuna, toate categoriile vor fi incluse.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Presetare filtru</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Folosește presetarea de filtru Playnite</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Când este activat, presetarea de filtru selectată va fi folosită în locul filtrelor individuale de mai jos. Creează presetări de filtru în vizualizarea principală a bibliotecii Playnite.</sys:String>
@@ -80,5 +71,5 @@ Eșuate: {1}</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Message_Errors">Au fost întâmpinate erori</sys:String>
     <!-- New: Permission prompt for apps.json write -->
     <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Title">ApolloSync</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Body">ApolloSync are nevoie de permisiunea de a scrie apps.json în Program Files. Permiți corectarea permisiunilor?</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Body">ApolloSync are nevoie de permisiunea de a scrie apps.json în Program Files.&#10;&#10;Aceasta acordă contului tău de utilizator Windows, și nimănui altcuiva, permisiunea de a modifica acel fișier. Windows va cere aprobarea administratorului. Modificarea este permanentă până când o anulezi.&#10;&#10;Permiți corectarea permisiunilor?</sys:String>
 </ResourceDictionary>

--- a/Localization/ru_RU.xaml
+++ b/Localization/ru_RU.xaml
@@ -42,17 +42,8 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_InstallationStatus">Фильтр по статусу установки</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames">Включать установленные игры</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames_Help">Если включено, только установленные игры будут рассматриваться для экспорта.</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_IncludedPlatforms">Фильтры платформ</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_IncludedPlatforms_Help">Выберите платформы для включения в экспорт. Если ни одна не выбрана, будут включены все платформы.</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_RequiredLabel">Фильтр по меткам</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_RequiredLabel_Help">Экспортировать только игры с этой меткой. Оставьте пустым, чтобы экспортировать все игры.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_NoLabel">Метка не требуется</sys:String>
     <sys:String x:Key="LOC_ApolloSync_DefaultLabel_Name">Apollo/Sunshine</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CreateDefaultLabel">Создать метку по умолчанию</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CompletionStatusFilter">Фильтр по статусу прохождения</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CompletionStatusFilter_Help">Выберите статусы прохождения для включения в экспорт. Если ни один не выбран, будут включены все статусы прохождения.</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CategoryFilter">Фильтр по категориям</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CategoryFilter_Help">Выберите категории для включения в экспорт. Если ни одна не выбрана, будут включены все категории.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Предустановка фильтра</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Использовать предустановку фильтра Playnite</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Если включено, вместо отдельных фильтров ниже будет использоваться выбранная предустановка фильтра. Создавайте предустановки фильтров в главном представлении библиотеки Playnite.</sys:String>
@@ -80,5 +71,5 @@
     <sys:String x:Key="LOC_ApolloSync_Message_Errors">Обнаружены ошибки</sys:String>
     <!-- New: Permission prompt for apps.json write -->
     <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Title">ApolloSync</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Body">ApolloSync необходимо разрешение на запись apps.json в Program Files. Разрешить исправление прав доступа?</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Body">ApolloSync необходимо разрешение на запись apps.json в Program Files.&#10;&#10;Это даст вашей учётной записи Windows — и только ей — право изменять этот файл. Windows запросит подтверждение администратора. Изменение сохранится, пока вы не отмените его.&#10;&#10;Разрешить исправление прав доступа?</sys:String>
 </ResourceDictionary>

--- a/Localization/sv_SE.xaml
+++ b/Localization/sv_SE.xaml
@@ -42,17 +42,8 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_InstallationStatus">Installationsstatusfilter</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames">Inkludera installerade spel</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames_Help">När aktiverat kommer bara installerade spel att övervägas för export.</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_IncludedPlatforms">Plattformsfilter</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_IncludedPlatforms_Help">Välj plattformar att inkludera i exporten. Om inga är valda inkluderas alla plattformar.</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_RequiredLabel">Etikettfilter</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_RequiredLabel_Help">Exportera bara spel med denna etikett. Lämna tomt för att exportera alla spel.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_NoLabel">Ingen etikett krävs</sys:String>
     <sys:String x:Key="LOC_ApolloSync_DefaultLabel_Name">Apollo/Sunshine</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CreateDefaultLabel">Skapa standardetikett</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CompletionStatusFilter">Slutförandestatusfilter</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CompletionStatusFilter_Help">Välj slutförandestatusar att inkludera i exporten. Om inga är valda inkluderas alla slutförandestatusar.</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CategoryFilter">Kategorifilter</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CategoryFilter_Help">Välj kategorier att inkludera i exporten. Om inga är valda inkluderas alla kategorier.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Filterförinställning</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Använd Playnite-filterförinställning</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">När aktiverat används den valda filterförinställningen istället för de enskilda filtren nedan. Skapa filterförinställningar i Playnites huvudbiblioteksvy.</sys:String>
@@ -80,5 +71,5 @@ Misslyckades: {1}</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Message_Errors">Fel uppstod</sys:String>
     <!-- New: Permission prompt for apps.json write -->
     <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Title">ApolloSync</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Body">ApolloSync behöver behörighet att skriva apps.json i Program Files. Tillåt rättning av behörigheter?</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Body">ApolloSync behöver behörighet att skriva apps.json i Program Files.&#10;&#10;Detta ger ditt Windows-användarkonto – och ingen annan – behörighet att ändra filen. Windows ber om godkännande av en administratör. Ändringen är permanent tills du ångrar den.&#10;&#10;Tillåt rättning av behörigheter?</sys:String>
 </ResourceDictionary>

--- a/Localization/tr_TR.xaml
+++ b/Localization/tr_TR.xaml
@@ -42,17 +42,8 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_InstallationStatus">Yükleme Durumu Filtresi</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames">Yüklü oyunları dahil et</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames_Help">Etkinleştirildiğinde, yalnızca yüklü oyunlar aktarım için değerlendirilir.</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_IncludedPlatforms">Platform Filtreleri</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_IncludedPlatforms_Help">Aktarıma dahil edilecek platformları seçin. Hiçbiri seçilmezse tüm platformlar dahil edilir.</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_RequiredLabel">Etiket Filtresi</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_RequiredLabel_Help">Yalnızca bu etikete sahip oyunları aktar. Tüm oyunları aktarmak için seçim yapmayın.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_NoLabel">Etiket gerekli değil</sys:String>
     <sys:String x:Key="LOC_ApolloSync_DefaultLabel_Name">Apollo/Sunshine</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CreateDefaultLabel">Varsayılan Etiket Oluştur</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CompletionStatusFilter">Tamamlanma Durumu Filtresi</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CompletionStatusFilter_Help">Aktarıma dahil edilecek tamamlanma durumlarını seçin. Hiçbiri seçilmezse tüm tamamlanma durumları dahil edilir.</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CategoryFilter">Kategori Filtresi</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CategoryFilter_Help">Aktarıma dahil edilecek kategorileri seçin. Hiçbiri seçilmezse tüm kategoriler dahil edilir.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Filtre Ön Ayarı</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Playnite Filtre Ön Ayarını Kullan</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Etkinleştirildiğinde, aşağıdaki ayrı filtreler yerine seçilen filtre ön ayarı kullanılır. Filtre ön ayarlarını Playnite'ın ana kütüphane görünümünde oluşturabilirsiniz.</sys:String>
@@ -80,5 +71,5 @@ Başarısız: {1}</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Message_Errors">Hatalarla karşılaşıldı</sys:String>
     <!-- New: Permission prompt for apps.json write -->
     <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Title">ApolloSync</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Body">ApolloSync, Program Files klasöründeki apps.json dosyasına yazmak için izin gerektirir. İzinlerin düzeltilmesine izin verilsin mi?</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Body">ApolloSync, Program Files klasöründeki apps.json dosyasına yazmak için izin gerektirir.&#10;&#10;Bu işlem, bu dosyayı değiştirme iznini yalnızca sizin Windows kullanıcı hesabınıza verir, başka hiç kimseye vermez. Windows yönetici onayı isteyecektir. Bu değişiklik, siz geri alana kadar kalıcıdır.&#10;&#10;İzinlerin düzeltilmesine izin verilsin mi?</sys:String>
 </ResourceDictionary>

--- a/Localization/uk_UA.xaml
+++ b/Localization/uk_UA.xaml
@@ -42,17 +42,8 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_InstallationStatus">Фільтр за статусом встановлення</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames">Включати встановлені ігри</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames_Help">Якщо увімкнено, лише встановлені ігри будуть розглядатися для експорту.</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_IncludedPlatforms">Фільтри платформ</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_IncludedPlatforms_Help">Виберіть платформи для включення в експорт. Якщо жодна не вибрана, будуть включені всі платформи.</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_RequiredLabel">Фільтр за мітками</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_RequiredLabel_Help">Експортувати лише ігри з цією міткою. Залиште порожнім, щоб експортувати всі ігри.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_NoLabel">Мітка не потрібна</sys:String>
     <sys:String x:Key="LOC_ApolloSync_DefaultLabel_Name">Apollo/Sunshine</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CreateDefaultLabel">Створити мітку за замовчуванням</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CompletionStatusFilter">Фільтр за статусом проходження</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CompletionStatusFilter_Help">Виберіть статуси проходження для включення в експорт. Якщо жоден не вибраний, будуть включені всі статуси проходження.</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CategoryFilter">Фільтр за категоріями</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CategoryFilter_Help">Виберіть категорії для включення в експорт. Якщо жодна не вибрана, будуть включені всі категорії.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Набір фільтрів</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Використовувати набір фільтрів Playnite</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Якщо увімкнено, замість окремих фільтрів нижче буде використовуватися вибраний набір фільтрів. Створюйте набори фільтрів у головному вигляді бібліотеки Playnite.</sys:String>
@@ -80,5 +71,5 @@
     <sys:String x:Key="LOC_ApolloSync_Message_Errors">Виявлено помилки</sys:String>
     <!-- New: Permission prompt for apps.json write -->
     <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Title">ApolloSync</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Body">ApolloSync потребує дозволу на запис apps.json у Program Files. Дозволити виправлення прав доступу?</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Body">ApolloSync потребує дозволу на запис apps.json у Program Files.&#10;&#10;Це надасть вашому обліковому запису Windows — і більше нікому — право змінювати цей файл. Windows запитає підтвердження адміністратора. Зміну буде збережено, доки ви її не скасуєте.&#10;&#10;Дозволити виправлення прав доступу?</sys:String>
 </ResourceDictionary>

--- a/Localization/zh_CN.xaml
+++ b/Localization/zh_CN.xaml
@@ -42,17 +42,8 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_InstallationStatus">安装状态筛选</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames">包含已安装的游戏</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames_Help">启用后，仅已安装的游戏会被纳入导出范围。</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_IncludedPlatforms">平台筛选</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_IncludedPlatforms_Help">选择要包含在导出中的平台。如果未选择任何平台，则包含所有平台。</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_RequiredLabel">标签筛选</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_RequiredLabel_Help">仅导出具有此标签的游戏。不选择则导出所有游戏。</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_NoLabel">不需要标签</sys:String>
     <sys:String x:Key="LOC_ApolloSync_DefaultLabel_Name">Apollo/Sunshine</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CreateDefaultLabel">创建默认标签</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CompletionStatusFilter">完成状态筛选</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CompletionStatusFilter_Help">选择要包含在导出中的完成状态。如果未选择，则包含所有完成状态。</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CategoryFilter">分类筛选</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CategoryFilter_Help">选择要包含在导出中的分类。如果未选择，则包含所有分类。</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">筛选预设</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">使用Playnite筛选预设</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">启用后，将使用所选的筛选预设替代下方的各项筛选条件。可在Playnite的主库视图中创建筛选预设。</sys:String>
@@ -80,5 +71,5 @@
     <sys:String x:Key="LOC_ApolloSync_Message_Errors">遇到错误</sys:String>
     <!-- New: Permission prompt for apps.json write -->
     <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Title">ApolloSync</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Body">ApolloSync需要权限以写入Program Files中的apps.json。是否允许修复权限？</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Body">ApolloSync需要权限以写入Program Files中的apps.json。&#10;&#10;此操作仅向您的Windows用户账户授予修改该文件的权限，其他任何人都不会获得该权限。Windows将请求管理员授权。此更改将一直保留，直到您手动撤销。&#10;&#10;是否允许修复权限？</sys:String>
 </ResourceDictionary>

--- a/Localization/zh_TW.xaml
+++ b/Localization/zh_TW.xaml
@@ -42,17 +42,8 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_InstallationStatus">安裝狀態篩選</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames">包含已安裝的遊戲</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames_Help">啟用後，僅已安裝的遊戲會被納入匯出範圍。</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_IncludedPlatforms">平台篩選</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_IncludedPlatforms_Help">選擇要包含在匯出中的平台。如果未選擇任何平台，則包含所有平台。</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_RequiredLabel">標籤篩選</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_RequiredLabel_Help">僅匯出具有此標籤的遊戲。不選擇則匯出所有遊戲。</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_NoLabel">不需要標籤</sys:String>
     <sys:String x:Key="LOC_ApolloSync_DefaultLabel_Name">Apollo/Sunshine</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CreateDefaultLabel">建立預設標籤</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CompletionStatusFilter">完成狀態篩選</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CompletionStatusFilter_Help">選擇要包含在匯出中的完成狀態。如果未選擇，則包含所有完成狀態。</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CategoryFilter">分類篩選</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Settings_CategoryFilter_Help">選擇要包含在匯出中的分類。如果未選擇，則包含所有分類。</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">篩選預設</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">使用Playnite篩選預設</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">啟用後，將使用所選的篩選預設取代下方的各項篩選條件。可在Playnite的主媒體庫檢視中建立篩選預設。</sys:String>
@@ -80,5 +71,5 @@
     <sys:String x:Key="LOC_ApolloSync_Message_Errors">發生錯誤</sys:String>
     <!-- New: Permission prompt for apps.json write -->
     <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Title">ApolloSync</sys:String>
-    <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Body">ApolloSync需要權限以寫入Program Files中的apps.json。是否允許修正權限？</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Permissions_Prompt_Body">ApolloSync需要權限以寫入Program Files中的apps.json。&#10;&#10;此操作僅授予您的Windows使用者帳戶修改該檔案的權限，其他人皆無法取得。Windows將要求系統管理員授權。此變更會一直保留，直到您自行還原為止。&#10;&#10;是否允許修正權限？</sys:String>
 </ResourceDictionary>

--- a/Models/ManagedStore.cs
+++ b/Models/ManagedStore.cs
@@ -1,12 +1,79 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace ApolloSync.Models
 {
     public class ManagedStore
     {
         public ConcurrentDictionary<Guid, Guid> GameToUuid { get; set; } = new ConcurrentDictionary<Guid, Guid>();
+
+        // Games the user explicitly removed from Apollo management. Recorded explicitly rather
+        // than inferred from "in the store but missing from apps.json", because the startup
+        // reconciliation prunes exactly those entries and would erase the signal.
+        //
+        // Access goes through the methods below rather than exposing the set: it is read from
+        // the background sync thread and written from UI-thread handlers, and those two are not
+        // serialized against each other by _configLock (the sync reads outside the lock).
+        private readonly HashSet<Guid> _manuallyRemoved = new HashSet<Guid>();
+        private readonly object _manuallyRemovedLock = new object();
+
+        /// <summary>True if the user explicitly removed this game from Apollo management.</summary>
+        public bool IsManuallyRemoved(Guid gameId)
+        {
+            lock (_manuallyRemovedLock)
+            {
+                return _manuallyRemoved.Contains(gameId);
+            }
+        }
+
+        /// <summary>Records that the user explicitly removed this game.</summary>
+        public void MarkManuallyRemoved(Guid gameId)
+        {
+            lock (_manuallyRemovedLock)
+            {
+                _manuallyRemoved.Add(gameId);
+            }
+        }
+
+        /// <summary>Clears the manual-removal record, e.g. when the user exports the game again.</summary>
+        public void ClearManualRemoval(Guid gameId)
+        {
+            lock (_manuallyRemovedLock)
+            {
+                _manuallyRemoved.Remove(gameId);
+            }
+        }
+
+        /// <summary>Snapshot for persistence and for iteration without holding the lock.</summary>
+        public List<Guid> ManuallyRemovedSnapshot()
+        {
+            lock (_manuallyRemovedLock)
+            {
+                return _manuallyRemoved.ToList();
+            }
+        }
+
+        /// <summary>Replaces the whole set, used when loading from settings.</summary>
+        public void ResetManuallyRemoved(IEnumerable<Guid> gameIds)
+        {
+            lock (_manuallyRemovedLock)
+            {
+                _manuallyRemoved.Clear();
+                if (gameIds != null)
+                {
+                    foreach (var id in gameIds)
+                    {
+                        _manuallyRemoved.Add(id);
+                    }
+                }
+            }
+        }
+
+        public int ManuallyRemovedCount
+        {
+            get { lock (_manuallyRemovedLock) { return _manuallyRemoved.Count; } }
+        }
     }
 }
-

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -34,5 +34,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+// Kept in step with extension.yaml by the bump workflow and enforced by pull_request.yml.
+[assembly: AssemblyVersion("1.3.0.0")]
+[assembly: AssemblyFileVersion("1.3.0.0")]

--- a/README.md
+++ b/README.md
@@ -5,12 +5,11 @@ A Playnite extension that syncs your game library to [Apollo](https://github.com
 ## Features
 
 - **Automatic sync** -- exports games matching your filters to Apollo/Sunshine's `apps.json` on install, library update, settings change, or Playnite startup (each individually configurable)
-- **Filter presets** -- uses your existing Playnite filter presets to decide what gets exported (OR logic when multiple are selected)
-- **Additional filters** -- platform, label, completion status, and category filters
+- **Filter presets** -- uses your existing Playnite filter presets to decide what gets exported (OR logic when multiple are selected). Filter by platform, category, completion status or anything else by building the preset in Playnite's library view.
 - **Pin/unpin** -- pin games to prevent auto-removal even when they stop matching filters
-- **Manual export/remove** -- right-click context menu for individual games
+- **Manual export/remove** -- right-click context menu for individual games. A game you remove by hand stays removed; sync will not re-add it until you export it again.
 - **Manage exported games** -- view and manage all synced games from the settings tab
-- **Non-destructive** -- only touches entries it created; preserves manual Apollo/Sunshine entries
+- **Preserves your own entries** -- only adds and removes the app entries it created. Note that saving `apps.json` also normalizes it: UUIDs on *all* entries are upper-cased, entries without a UUID are moved to the end, and any array element that is not a JSON object is dropped.
 - **Notification control** -- always, on sync only, or never
 - **Permissions handling** -- prompts to fix write permissions if `apps.json` is in a protected directory
 
@@ -22,7 +21,7 @@ Download the latest `.pext` from [Releases](https://github.com/sharkusmanch/play
 
 1. Go to **Extensions** > **ApolloSync** > **Settings**
 2. Set the path to your `apps.json` (or leave blank for default location)
-3. Select one or more Playnite filter presets and/or configure platform/label/category/completion status filters
+3. Select one or more Playnite filter presets (create them in Playnite's main library view first)
 4. Enable desired sync triggers (library update, startup, settings change)
 
 ## Building

--- a/Services/ConfigService.cs
+++ b/Services/ConfigService.cs
@@ -76,47 +76,17 @@ namespace ApolloSync.Services
                 var jsonContent = config.ToString(Newtonsoft.Json.Formatting.Indented);
                 logger.Debug($"ConfigService.Save - Writing config with {((JArray)config["apps"])?.Count ?? 0} apps");
 
-                // Write content to a temp file in %TEMP% (always user-writable) then copy it
-                // over the destination. This ensures the full content is written before we
-                // touch apps.json, without needing directory-level create/delete permissions
-                // on the (potentially protected) Apollo install path.
-                var tmpPath = Path.Combine(Path.GetTempPath(), "apollosync_" + Path.GetRandomFileName() + ".tmp");
-                try
+                var bytes = Encoding.UTF8.GetBytes(jsonContent);
+
+                // Prefer an atomic same-directory swap. File.Replace exchanges the directory
+                // entry in a single operation and keeps the previous contents as a .bak, so an
+                // interrupted write can never leave apps.json truncated. It needs create rights
+                // in the destination directory, which we do not have when apps.json lives in
+                // Program Files and only the file itself was granted modify (see
+                // TryFixFilePermissionsWithElevation) — fall back to a copy-based write there.
+                if (!TryReplaceInPlace(resolvedPath, bytes))
                 {
-                    var attempts = 0;
-                    const int maxAttempts = 3;
-                    while (true)
-                    {
-                        // Delete any leftover tmp from a previous failed attempt so FileMode.CreateNew can succeed.
-                        try { if (File.Exists(tmpPath)) File.Delete(tmpPath); } catch { }
-                        try
-                        {
-                            // FileMode.CreateNew fails if a file (or symlink to an existing
-                            // file) already exists at tmpPath, preventing symlink substitution.
-                            using (var fs = new FileStream(tmpPath, FileMode.CreateNew, FileAccess.Write, FileShare.None))
-                            {
-                                var bytes = Encoding.UTF8.GetBytes(jsonContent);
-                                fs.Write(bytes, 0, bytes.Length);
-                            }
-                            File.Copy(tmpPath, resolvedPath, overwrite: true);
-                            break;
-                        }
-                        catch (UnauthorizedAccessException)
-                        {
-                            throw; // handled by caller for permission prompt
-                        }
-                        catch (IOException)
-                        {
-                            attempts++;
-                            if (attempts >= maxAttempts)
-                                throw;
-                            Thread.Sleep(150 * attempts);
-                        }
-                    }
-                }
-                finally
-                {
-                    try { if (File.Exists(tmpPath)) File.Delete(tmpPath); } catch { }
+                    CopyThroughTempFile(resolvedPath, bytes);
                 }
                 logger.Info($"ConfigService.Save - Successfully saved apps.json to: {resolvedPath}");
             }
@@ -125,6 +95,168 @@ namespace ApolloSync.Services
                 logger.Error(ex, $"ConfigService.Save - Failed to save apps.json to path: {path}");
                 throw;
             }
+        }
+
+        /// <summary>
+        /// Writes <paramref name="bytes"/> to a temp file beside <paramref name="destination"/> and
+        /// swaps it in atomically, keeping the previous contents as "&lt;destination&gt;.bak".
+        /// Returns false if the destination directory cannot be written to, so the caller can fall
+        /// back to <see cref="CopyThroughTempFile"/>.
+        /// </summary>
+        private static bool TryReplaceInPlace(string destination, byte[] bytes)
+        {
+            var dir = Path.GetDirectoryName(destination);
+            if (string.IsNullOrEmpty(dir))
+            {
+                return false;
+            }
+
+            var tmpPath = Path.Combine(dir, "apollosync_" + Path.GetRandomFileName() + ".tmp");
+            try
+            {
+                // FileMode.CreateNew fails if a file (or symlink to an existing file) already
+                // exists at tmpPath, preventing symlink substitution.
+                using (var fs = new FileStream(tmpPath, FileMode.CreateNew, FileAccess.Write, FileShare.None))
+                {
+                    fs.Write(bytes, 0, bytes.Length);
+                    // Force to disk before the swap, so the directory entry can never point at
+                    // content the OS has not yet committed.
+                    fs.Flush(flushToDisk: true);
+                }
+
+                if (File.Exists(destination))
+                {
+                    File.Replace(tmpPath, destination, destination + ".bak", ignoreMetadataErrors: true);
+                }
+                else
+                {
+                    File.Move(tmpPath, destination);
+                }
+
+                logger.Debug($"ConfigService - Atomically replaced {destination}");
+                return true;
+            }
+            catch (Exception ex)
+            {
+                // Expected when the install directory is not writable by the current user; the
+                // caller retries via the copy path, which only needs rights on the file itself.
+                logger.Debug($"ConfigService - Atomic replace unavailable for {destination} ({ex.GetType().Name}: {ex.Message}); falling back to copy");
+                return false;
+            }
+            finally
+            {
+                // No-op when the swap succeeded — Replace/Move consumed the temp file.
+                try { if (File.Exists(tmpPath)) File.Delete(tmpPath); } catch { }
+            }
+        }
+
+        /// <summary>
+        /// Writes <paramref name="bytes"/> to %TEMP% (always user-writable) and copies the result
+        /// over <paramref name="destination"/>. Used when the destination directory is protected
+        /// and only the file itself is writable, so no atomic swap is possible.
+        /// </summary>
+        internal static void CopyThroughTempFile(string destination, byte[] bytes)
+        {
+            // Back up the previous contents ONCE, before anything can damage the destination.
+            // Taking this inside the retry loop would let attempt 2 copy a half-written
+            // destination over the only good backup.
+            BackupExistingFile(destination);
+
+            var tmpPath = Path.Combine(Path.GetTempPath(), "apollosync_" + Path.GetRandomFileName() + ".tmp");
+            try
+            {
+                var attempts = 0;
+                const int maxAttempts = 3;
+                while (true)
+                {
+                    // Delete any leftover tmp from a previous failed attempt so FileMode.CreateNew can succeed.
+                    try { if (File.Exists(tmpPath)) File.Delete(tmpPath); } catch { }
+                    try
+                    {
+                        // FileMode.CreateNew fails if a file (or symlink to an existing
+                        // file) already exists at tmpPath, preventing symlink substitution.
+                        using (var fs = new FileStream(tmpPath, FileMode.CreateNew, FileAccess.Write, FileShare.None))
+                        {
+                            fs.Write(bytes, 0, bytes.Length);
+                            fs.Flush(flushToDisk: true);
+                        }
+
+                        File.Copy(tmpPath, destination, overwrite: true);
+                        return;
+                    }
+                    catch (UnauthorizedAccessException)
+                    {
+                        throw; // handled by caller for permission prompt
+                    }
+                    catch (IOException)
+                    {
+                        attempts++;
+                        if (attempts >= maxAttempts)
+                            throw;
+                        Thread.Sleep(150 * attempts);
+                    }
+                }
+            }
+            finally
+            {
+                try { if (File.Exists(tmpPath)) File.Delete(tmpPath); } catch { }
+            }
+        }
+
+        /// <summary>
+        /// Copies the current contents of <paramref name="destination"/> aside, so an interrupted
+        /// write is recoverable. Prefers "&lt;destination&gt;.bak"; when the install directory is not
+        /// writable — the usual case for the default Program Files install, where only the file
+        /// itself was granted modify — falls back to the user's local application data, which
+        /// always is. Failing to back up is logged, never fatal.
+        /// </summary>
+        private static void BackupExistingFile(string destination)
+        {
+            if (!File.Exists(destination))
+            {
+                return;
+            }
+
+            try
+            {
+                File.Copy(destination, destination + ".bak", overwrite: true);
+                return;
+            }
+            catch (Exception ex)
+            {
+                logger.Debug($"ConfigService - Cannot write a backup beside {destination} ({ex.GetType().Name}); falling back to local app data");
+            }
+
+            try
+            {
+                var backupPath = GetFallbackBackupPath(destination);
+                Directory.CreateDirectory(Path.GetDirectoryName(backupPath));
+                File.Copy(destination, backupPath, overwrite: true);
+                logger.Info($"ConfigService - Backed up {destination} to {backupPath}");
+            }
+            catch (Exception ex)
+            {
+                logger.Warn($"ConfigService - Could not write any backup for {destination}: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// A stable, always-writable backup location. The destination path is flattened into the
+        /// file name so Apollo and Sunshine configs cannot overwrite each other's backup.
+        /// </summary>
+        internal static string GetFallbackBackupPath(string destination)
+        {
+            var flattened = destination;
+            foreach (var invalid in Path.GetInvalidFileNameChars())
+            {
+                flattened = flattened.Replace(invalid, '_');
+            }
+
+            return Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "ApolloSync",
+                "backups",
+                flattened + ".bak");
         }
 
         /// <summary>

--- a/Settings/ApolloSyncSettings.cs
+++ b/Settings/ApolloSyncSettings.cs
@@ -16,19 +16,6 @@ namespace ApolloSync
         Never
     }
 
-    public class LabelOption
-    {
-        public string Name { get; set; }
-        public Guid? Id { get; set; }
-    }
-
-    public class CompletionStatusOption
-    {
-        public string Name { get; set; }
-        public CompletionStatus Status { get; set; }
-        public bool IsSelected { get; set; }
-    }
-
     public class ApolloSyncSettings : ObservableObject
     {
         private string _appsJsonPath = string.Empty;
@@ -93,6 +80,13 @@ namespace ApolloSync
         {
             get => _managedGameMappings;
             set => SetValue(ref _managedGameMappings, value);
+        }
+
+        private List<Guid> _manuallyRemovedGames = new List<Guid>();
+        public List<Guid> ManuallyRemovedGames
+        {
+            get => _manuallyRemovedGames;
+            set => SetValue(ref _manuallyRemovedGames, value);
         }
 
         // No non-serialized properties at this time.

--- a/Settings/ApolloSyncSettingsView.xaml.cs
+++ b/Settings/ApolloSyncSettingsView.xaml.cs
@@ -15,27 +15,24 @@ namespace ApolloSync
     {
         private static readonly ILogger logger = LogManager.GetLogger();
 
+        // Held directly rather than looked up with FindChild: the Manage Games tab is not the
+        // selected tab when the window opens, so its content is not in the visual tree yet and
+        // a VisualTreeHelper search returns null.
+        private StackPanel _managedGamesPanel;
+
         public ApolloSyncSettingsView()
         {
             BuildUI();
 
-            // Auto-load managed games when the settings window opens
+            // Auto-load managed games when the settings window opens. BuildUI runs before
+            // Playnite assigns the DataContext, so the list cannot be populated there.
             Loaded += (sender, e) =>
             {
-                // Wait for DataContext to be set, then refresh managed games
                 Dispatcher.BeginInvoke(new System.Action(() =>
                 {
-                    if (DataContext != null)
+                    if (DataContext != null && _managedGamesPanel != null)
                     {
-                        var manageGamesTab = FindChild<TabItem>("ManageGamesTab");
-                        if (manageGamesTab != null)
-                        {
-                            var gamesPanel = FindChild<StackPanel>("ManagedGamesPanel");
-                            if (gamesPanel != null)
-                            {
-                                RefreshManagedGamesList(gamesPanel);
-                            }
-                        }
+                        RefreshManagedGamesList(_managedGamesPanel);
                     }
                 }), System.Windows.Threading.DispatcherPriority.Background);
             };
@@ -222,142 +219,10 @@ namespace ApolloSync
         {
             var stack = new StackPanel { Margin = new Thickness(8) };
 
-            // Platform Filters (collapsible)
-            var platformExpander = new Expander
-            {
-                Header = ResourceProvider.GetString("LOC_ApolloSync_Settings_IncludedPlatforms"),
-                IsExpanded = false,
-                Margin = new Thickness(0, 0, 0, 8)
-            };
-
-            var platformContentPanel = new StackPanel();
-
-            // Create platform selection table
-            var platformsBorder = new Border
-            {
-                BorderBrush = System.Windows.Media.Brushes.Gray,
-                BorderThickness = new Thickness(1),
-                Margin = new Thickness(0, 4, 0, 0)
-            };
-
-            var platformsScrollViewer = new ScrollViewer { MaxHeight = 150, VerticalScrollBarVisibility = ScrollBarVisibility.Auto };
-            var platformsPanel = new StackPanel { Name = "PlatformsPanel" };
-            platformsScrollViewer.Content = platformsPanel;
-            platformsBorder.Child = platformsScrollViewer;
-            platformContentPanel.Children.Add(platformsBorder);
-
-            // Add "Select All" and "Clear All" buttons
-            var buttonPanel = new StackPanel { Orientation = Orientation.Horizontal, Margin = new Thickness(0, 4, 0, 0) };
-            var selectAllBtn = new Button { Content = "Select All", Width = 80, Margin = new Thickness(0, 0, 4, 0) };
-            var clearAllBtn = new Button { Content = "Clear All", Width = 80 };
-            // Platform filtering disabled - using filter presets only
-            // selectAllBtn.Click += SelectAllPlatforms_Click;
-            // clearAllBtn.Click += ClearAllPlatforms_Click;
-            buttonPanel.Children.Add(selectAllBtn);
-            buttonPanel.Children.Add(clearAllBtn);
-            platformContentPanel.Children.Add(buttonPanel);
-            platformContentPanel.Children.Add(new TextBlock { Text = ResourceProvider.GetString("LOC_ApolloSync_Settings_IncludedPlatforms_Help"), TextWrapping = TextWrapping.Wrap, Margin = new Thickness(0, 4, 0, 0) });
-
-            // Platform filtering disabled - using filter presets only
-            // if (DataContext is ApolloSyncSettingsViewModel vm)
-            // {
-            //     UpdatePlatformCheckboxes(platformsPanel);
-            // }
-            // DataContextChanged += (s, e) =>
-            // {
-            //     if (DataContext is ApolloSyncSettingsViewModel viewModel)
-            //     {
-            //         UpdatePlatformCheckboxes(platformsPanel);
-            //     }
-            // };
-
-            platformExpander.Content = platformContentPanel;
-            platformExpander.Visibility = Visibility.Collapsed; // TEMP: Disable custom filters
-            stack.Children.Add(platformExpander);
-
-            // Label Filter (collapsible)
-            var labelExpander = new Expander
-            {
-                Header = ResourceProvider.GetString("LOC_ApolloSync_Settings_RequiredLabel"),
-                IsExpanded = false,
-                Margin = new Thickness(0, 0, 0, 8)
-            };
-
-            var labelContentPanel = new StackPanel();
-            var labelCombo = new ComboBox { MinWidth = 200, Margin = new Thickness(0, 4, 0, 0) };
-            labelCombo.SetBinding(ComboBox.ItemsSourceProperty, new Binding("LabelOptions"));
-            labelCombo.SetBinding(ComboBox.SelectedValueProperty, new Binding("Settings.RequiredLabelId") { Mode = BindingMode.TwoWay });
-            labelCombo.DisplayMemberPath = "Name";
-            labelCombo.SelectedValuePath = "Id";
-            labelContentPanel.Children.Add(labelCombo);
-
-            var btnCreateLabel = new Button
-            {
-                Content = ResourceProvider.GetString("LOC_ApolloSync_Settings_CreateDefaultLabel"),
-                Width = 150,
-                HorizontalAlignment = HorizontalAlignment.Left,
-                Margin = new Thickness(0, 4, 0, 0)
-            };
-            btnCreateLabel.Click += CreateDefaultLabel_Click;
-            labelContentPanel.Children.Add(btnCreateLabel);
-            labelContentPanel.Children.Add(new TextBlock { Text = ResourceProvider.GetString("LOC_ApolloSync_Settings_RequiredLabel_Help"), TextWrapping = TextWrapping.Wrap, Margin = new Thickness(0, 4, 0, 0) });
-
-            labelExpander.Content = labelContentPanel;
-            labelExpander.Visibility = Visibility.Collapsed; // TEMP: Disable custom filters
-            stack.Children.Add(labelExpander);
-
-            // Completion Status Filter (collapsible)
-            var completionExpander = new Expander
-            {
-                Header = ResourceProvider.GetString("LOC_ApolloSync_Settings_CompletionStatusFilter"),
-                IsExpanded = false,
-                Margin = new Thickness(0, 0, 0, 8)
-            };
-
-            var completionContentPanel = new StackPanel();
-
-            // Create completion status selection table
-            var completionBorder = new Border
-            {
-                BorderBrush = System.Windows.Media.Brushes.Gray,
-                BorderThickness = new Thickness(1),
-                Margin = new Thickness(0, 4, 0, 0)
-            };
-
-            var completionScrollViewer = new ScrollViewer { MaxHeight = 150, VerticalScrollBarVisibility = ScrollBarVisibility.Auto };
-            var completionPanel = new StackPanel { Name = "CompletionPanel" };
-            completionScrollViewer.Content = completionPanel;
-            completionBorder.Child = completionScrollViewer;
-            completionContentPanel.Children.Add(completionBorder);
-
-            // Add "Select All" and "Clear All" buttons for completion status
-            var completionButtonPanel = new StackPanel { Orientation = Orientation.Horizontal, Margin = new Thickness(0, 4, 0, 0) };
-            var selectAllCompletionBtn = new Button { Content = "Select All", Width = 80, Margin = new Thickness(0, 0, 4, 0) };
-            var clearAllCompletionBtn = new Button { Content = "Clear All", Width = 80 };
-            // Completion status filtering disabled - using filter presets only
-            // selectAllCompletionBtn.Click += SelectAllCompletionStatuses_Click;
-            // clearAllCompletionBtn.Click += ClearAllCompletionStatuses_Click;
-            completionButtonPanel.Children.Add(selectAllCompletionBtn);
-            completionButtonPanel.Children.Add(clearAllCompletionBtn);
-            completionContentPanel.Children.Add(completionButtonPanel);
-            completionContentPanel.Children.Add(new TextBlock { Text = ResourceProvider.GetString("LOC_ApolloSync_Settings_CompletionStatusFilter_Help"), TextWrapping = TextWrapping.Wrap, Margin = new Thickness(0, 4, 0, 0) });
-
-            // Completion status filtering disabled - using filter presets only
-            // if (DataContext is ApolloSyncSettingsViewModel vm2)
-            // {
-            //     UpdateCompletionStatusCheckboxes(completionPanel);
-            // }
-            // DataContextChanged += (s, e) =>
-            // {
-            //     if (DataContext is ApolloSyncSettingsViewModel viewModel2)
-            //     {
-            //         UpdateCompletionStatusCheckboxes(completionPanel);
-            //     }
-            // };
-
-            completionExpander.Content = completionContentPanel;
-            completionExpander.Visibility = Visibility.Collapsed; // TEMP: Disable custom filters
-            stack.Children.Add(completionExpander);
+            // Filter presets are the only filter mechanism. Platform, label, completion status
+            // and category sections used to sit here, permanently Visibility.Collapsed and bound
+            // to settings properties that never existed. Playnite's own filter presets already
+            // cover those dimensions.
 
             // Filter Presets (collapsible)
             var filterPresetExpander = new Expander
@@ -419,59 +284,6 @@ namespace ApolloSync
             filterPresetExpander.Content = filterPresetContentPanel;
             stack.Children.Add(filterPresetExpander);
 
-            // Category Filter (collapsible)
-            var categoryExpander = new Expander
-            {
-                Header = ResourceProvider.GetString("LOC_ApolloSync_Settings_CategoryFilter"),
-                IsExpanded = false,
-                Margin = new Thickness(0, 0, 0, 8)
-            };
-
-            var categoryContentPanel = new StackPanel();
-
-            // Create category selection table
-            var categoryBorder = new Border
-            {
-                BorderBrush = System.Windows.Media.Brushes.Gray,
-                BorderThickness = new Thickness(1),
-                Margin = new Thickness(0, 4, 0, 0)
-            };
-
-            var categoryScrollViewer = new ScrollViewer { MaxHeight = 150, VerticalScrollBarVisibility = ScrollBarVisibility.Auto };
-            var categoryPanel = new StackPanel { Name = "CategoriesPanel" };
-            categoryScrollViewer.Content = categoryPanel;
-            categoryBorder.Child = categoryScrollViewer;
-            categoryContentPanel.Children.Add(categoryBorder);
-
-            // Add "Select All" and "Clear All" buttons for categories
-            var categoryButtonPanel = new StackPanel { Orientation = Orientation.Horizontal, Margin = new Thickness(0, 4, 0, 0) };
-            var selectAllCategoryBtn = new Button { Content = "Select All", Width = 80, Margin = new Thickness(0, 0, 4, 0) };
-            var clearAllCategoryBtn = new Button { Content = "Clear All", Width = 80 };
-            // Category filtering disabled - using filter presets only
-            // selectAllCategoryBtn.Click += SelectAllCategories_Click;
-            // clearAllCategoryBtn.Click += ClearAllCategories_Click;
-            categoryButtonPanel.Children.Add(selectAllCategoryBtn);
-            categoryButtonPanel.Children.Add(clearAllCategoryBtn);
-            categoryContentPanel.Children.Add(categoryButtonPanel);
-            categoryContentPanel.Children.Add(new TextBlock { Text = ResourceProvider.GetString("LOC_ApolloSync_Settings_CategoryFilter_Help"), TextWrapping = TextWrapping.Wrap, Margin = new Thickness(0, 4, 0, 0) });
-
-            // Category filtering disabled - using filter presets only
-            // if (DataContext is ApolloSyncSettingsViewModel vm3)
-            // {
-            //     UpdateCategoryCheckboxes(categoryPanel);
-            // }
-            // DataContextChanged += (s, e) =>
-            // {
-            //     if (DataContext is ApolloSyncSettingsViewModel viewModel3)
-            //     {
-            //         UpdateCategoryCheckboxes(categoryPanel);
-            //     }
-            // };
-
-            categoryExpander.Content = categoryContentPanel;
-            categoryExpander.Visibility = Visibility.Collapsed; // TEMP: Disable custom filters
-            stack.Children.Add(categoryExpander);
-
             return stack;
         }
 
@@ -493,6 +305,7 @@ namespace ApolloSync
 
             var gamesScrollViewer = new ScrollViewer { VerticalScrollBarVisibility = ScrollBarVisibility.Auto };
             var gamesPanel = new StackPanel { Name = "ManagedGamesPanel" };
+            _managedGamesPanel = gamesPanel;
             gamesScrollViewer.Content = gamesPanel;
             gamesListBorder.Child = gamesScrollViewer;
             stack.Children.Add(gamesListBorder);
@@ -518,8 +331,7 @@ namespace ApolloSync
             // Help text
             stack.Children.Add(new TextBlock { Text = ResourceProvider.GetString("LOC_ApolloSync_Settings_ManageGames_Help"), TextWrapping = TextWrapping.Wrap, Margin = new Thickness(0, 4, 0, 0) });
 
-            // Populate games list when tab is created
-            RefreshManagedGamesList(gamesPanel);
+            // Populated from the Loaded handler — the DataContext is not assigned yet here.
 
             return stack;
         }
@@ -616,45 +428,43 @@ namespace ApolloSync
             }
         }
 
-        private void CreateDefaultLabel_Click(object sender, RoutedEventArgs e)
-        {
-            // Default label creation disabled - using filter presets only
-            // if (DataContext is ApolloSyncSettingsViewModel vm)
-            // {
-            //     vm.CreateDefaultLabel();
-            // }
-        }
-
         // Manage Games Tab Methods
         private void RefreshManagedGames_Click(object sender, RoutedEventArgs e)
         {
-            var gamesPanel = FindChild<StackPanel>("ManagedGamesPanel");
-            if (gamesPanel != null)
+            if (_managedGamesPanel != null)
             {
-                RefreshManagedGamesList(gamesPanel);
+                RefreshManagedGamesList(_managedGamesPanel);
             }
         }
 
         private void RemoveSelectedGames_Click(object sender, RoutedEventArgs e)
         {
-            var gamesPanel = FindChild<StackPanel>("ManagedGamesPanel");
-            if (gamesPanel != null && DataContext is ApolloSyncSettingsViewModel vm)
+            if (_managedGamesPanel != null && DataContext is ApolloSyncSettingsViewModel vm)
             {
-                var selectedGames = GetSelectedManagedGames(gamesPanel);
+                var selectedGames = GetSelectedManagedGames(_managedGamesPanel);
                 if (selectedGames.Any())
                 {
-                    vm.RemoveGamesFromManaged(selectedGames);
-                    RefreshManagedGamesList(gamesPanel);
+                    // Off the UI thread: RemoveGamesFromManaged waits for any running sync and
+                    // writes apps.json under _configLock, and a failed write dispatches a
+                    // permission prompt back to this thread. Doing that synchronously here
+                    // deadlocks.
+                    System.Threading.Tasks.Task.Run(() => vm.RemoveGamesFromManaged(selectedGames))
+                        .ContinueWith(_ => Dispatcher.BeginInvoke(new System.Action(() =>
+                        {
+                            if (_managedGamesPanel != null)
+                            {
+                                RefreshManagedGamesList(_managedGamesPanel);
+                            }
+                        })));
                 }
             }
         }
 
         private void PinSelectedGames_Click(object sender, RoutedEventArgs e)
         {
-            var gamesPanel = FindChild<StackPanel>("ManagedGamesPanel");
-            if (gamesPanel != null && DataContext is ApolloSyncSettingsViewModel vm)
+            if (_managedGamesPanel != null && DataContext is ApolloSyncSettingsViewModel vm)
             {
-                var selectedGames = GetSelectedManagedGames(gamesPanel);
+                var selectedGames = GetSelectedManagedGames(_managedGamesPanel);
                 foreach (var gameId in selectedGames)
                 {
                     if (!vm.Settings.PinnedGameIds.Contains(gameId))
@@ -662,21 +472,20 @@ namespace ApolloSync
                         vm.Settings.PinnedGameIds.Add(gameId);
                     }
                 }
-                RefreshManagedGamesList(gamesPanel);
+                RefreshManagedGamesList(_managedGamesPanel);
             }
         }
 
         private void UnpinSelectedGames_Click(object sender, RoutedEventArgs e)
         {
-            var gamesPanel = FindChild<StackPanel>("ManagedGamesPanel");
-            if (gamesPanel != null && DataContext is ApolloSyncSettingsViewModel vm)
+            if (_managedGamesPanel != null && DataContext is ApolloSyncSettingsViewModel vm)
             {
-                var selectedGames = GetSelectedManagedGames(gamesPanel);
+                var selectedGames = GetSelectedManagedGames(_managedGamesPanel);
                 foreach (var gameId in selectedGames)
                 {
                     vm.Settings.PinnedGameIds.Remove(gameId);
                 }
-                RefreshManagedGamesList(gamesPanel);
+                RefreshManagedGamesList(_managedGamesPanel);
             }
         }
 
@@ -783,11 +592,6 @@ namespace ApolloSync
                 }
             }
             return selectedGames;
-        }
-
-        private T FindChild<T>(string name) where T : FrameworkElement
-        {
-            return FindChild<T>(this, name);
         }
 
         private T FindChild<T>(DependencyObject parent, string name) where T : FrameworkElement

--- a/Tests/ApolloSync.Tests.csproj
+++ b/Tests/ApolloSync.Tests.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.3.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.3.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-  <PackageReference Include="PlayniteSDK" Version="6.16.0" />
+    <PackageReference Include="PlayniteSDK" Version="6.16.0" />
   <PackageReference Include="Moq" Version="4.20.72" />
   </ItemGroup>
 

--- a/Tests/AppsJsonManagementTests.cs
+++ b/Tests/AppsJsonManagementTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Collections.Generic;
 using ApolloSync.Models;
 using ApolloSync.Services;
@@ -65,6 +66,36 @@ namespace ApolloSync.Tests
         }
 
         [TestMethod]
+        public void Save_KeepsBackupOfPreviousContents()
+        {
+            // The write must be survivable: the previous apps.json is recoverable from .bak
+            // if the process dies before the new contents are committed.
+            var configService = new ConfigService();
+            var sync = new SyncService();
+            var store = new ManagedStore();
+            var path = CreateTempFilePath();
+
+            var first = new Game("First") { Id = Guid.NewGuid(), InstallDirectory = "C:\\F" };
+            var config = configService.Load(path);
+            Assert.IsTrue(sync.AddOrUpdate(config, store, first));
+            configService.Save(path, config);
+            Assert.IsFalse(File.Exists(path + ".bak"), "No backup expected on first write");
+
+            var second = new Game("Second") { Id = Guid.NewGuid(), InstallDirectory = "C:\\S" };
+            Assert.IsTrue(sync.AddOrUpdate(config, store, second));
+            configService.Save(path, config);
+
+            Assert.IsTrue(File.Exists(path + ".bak"), "Second write should leave a backup");
+            var backup = JObject.Parse(File.ReadAllText(path + ".bak"));
+            var backupNames = ((JArray)backup["apps"]).Select(a => (string)((JObject)a)["name"]).ToList();
+            CollectionAssert.AreEquivalent(new[] { "First" }, backupNames);
+
+            var current = JObject.Parse(File.ReadAllText(path));
+            var currentNames = ((JArray)current["apps"]).Select(a => (string)((JObject)a)["name"]).ToList();
+            CollectionAssert.AreEquivalent(new[] { "First", "Second" }, currentNames);
+        }
+
+        [TestMethod]
         public void Remove_Selected_Single_Removes_From_Apps_And_Store()
         {
             // Arrange
@@ -86,56 +117,237 @@ namespace ApolloSync.Tests
             Assert.IsFalse(store.GameToUuid.ContainsKey(game.Id));
         }
 
+        // ── ShouldRemoveManagedGame ───────────────────────────────────────────────
+        // The real decision rule used by RemoveFilteredOutGames. These previously
+        // reimplemented the loop inline, which left the production method untested.
+
+        [TestMethod]
+        public void ShouldRemoveManagedGame_RemovesUnpinnedGameThatNoLongerMatches()
+        {
+            Assert.IsTrue(global::ApolloSync.ApolloSync.ShouldRemoveManagedGame(
+                gameExistsInLibrary: true, isPinned: false, meetsFilters: false, filterEvaluationFailed: false));
+        }
+
+        [TestMethod]
+        public void ShouldRemoveManagedGame_KeepsMatchingGame()
+        {
+            Assert.IsFalse(global::ApolloSync.ApolloSync.ShouldRemoveManagedGame(
+                gameExistsInLibrary: true, isPinned: false, meetsFilters: true, filterEvaluationFailed: false));
+        }
+
+        [TestMethod]
+        public void ShouldRemoveManagedGame_KeepsPinnedGameThatNoLongerMatches()
+        {
+            Assert.IsFalse(global::ApolloSync.ApolloSync.ShouldRemoveManagedGame(
+                gameExistsInLibrary: true, isPinned: true, meetsFilters: false, filterEvaluationFailed: false));
+        }
+
+        [TestMethod]
+        public void ShouldRemoveManagedGame_RemovesGameDeletedFromLibrary()
+        {
+            Assert.IsTrue(global::ApolloSync.ApolloSync.ShouldRemoveManagedGame(
+                gameExistsInLibrary: false, isPinned: false, meetsFilters: false, filterEvaluationFailed: false));
+        }
+
+        [TestMethod]
+        public void ShouldRemoveManagedGame_RemovesGameDeletedFromLibraryEvenWhenPinned()
+        {
+            // Pinning cannot preserve a game that no longer exists.
+            Assert.IsTrue(global::ApolloSync.ApolloSync.ShouldRemoveManagedGame(
+                gameExistsInLibrary: false, isPinned: true, meetsFilters: false, filterEvaluationFailed: false));
+        }
+
+        [TestMethod]
+        public void ShouldRemoveManagedGame_KeepsGameWhenFilterEvaluationFailed()
+        {
+            // Regression: a throwing filter preset used to surface as "does not match", which
+            // deleted every non-pinned managed entry on one transient failure.
+            Assert.IsFalse(global::ApolloSync.ApolloSync.ShouldRemoveManagedGame(
+                gameExistsInLibrary: true, isPinned: false, meetsFilters: false, filterEvaluationFailed: true));
+        }
+
+        // ── Removal wiring ────────────────────────────────────────────────────────
+
         [TestMethod]
         public void Remove_FilteredOut_NotPinned_Removes_Entry()
         {
-            // This test simulates the logic of RemoveFilteredOutGames without using ApolloSync internals.
             // Arrange
-            var config = new JObject { ["apps"] = new JArray() };
+            var sync = new SyncService();
             var store = new ManagedStore();
+            var config = new JObject { ["apps"] = new JArray() };
 
-            var g1 = new Playnite.SDK.Models.Game("Match") { Id = Guid.NewGuid() };
-            var g2 = new Playnite.SDK.Models.Game("NoMatch") { Id = Guid.NewGuid() };
+            var match = new Game("Match") { Id = Guid.NewGuid(), InstallDirectory = "C:\\M" };
+            var noMatch = new Game("NoMatch") { Id = Guid.NewGuid(), InstallDirectory = "C:\\N" };
 
-            var uuid1 = Guid.NewGuid();
-            var uuid2 = Guid.NewGuid();
-            store.GameToUuid[g1.Id] = uuid1;
-            store.GameToUuid[g2.Id] = uuid2;
+            Assert.IsTrue(sync.AddOrUpdate(config, store, match));
+            Assert.IsTrue(sync.AddOrUpdate(config, store, noMatch));
 
-            var apps = (JArray)config["apps"];
-            apps.Add(new JObject { ["name"] = g1.Name, ["uuid"] = uuid1.ToString().ToUpperInvariant() });
-            apps.Add(new JObject { ["name"] = g2.Name, ["uuid"] = uuid2.ToString().ToUpperInvariant() });
-
-            // Simulate filter: only g1 matches, g2 does not, and g2 is not pinned.
+            // Act: apply the production decision rule, then the production removal.
             var pinned = new HashSet<Guid>();
-            Func<Playnite.SDK.Models.Game, bool> meetsFilter = game => game.Id == g1.Id;
-
-            // Act: perform simplified removal similar to RemoveFilteredOutGames
-            var removedCount = 0;
-            var toRemoveApps = new System.Collections.Generic.List<JObject>();
-            var toRemoveGames = new System.Collections.Generic.List<Guid>();
-            foreach (var kv in store.GameToUuid.ToList())
+            foreach (var game in new[] { match, noMatch })
             {
-                var gameId = kv.Key;
-                var appUuid = kv.Value;
-                // Look up pseudo game by mapping
-                var game = gameId == g1.Id ? g1 : g2;
-                if (pinned.Contains(gameId)) continue;
-                if (!meetsFilter(game))
+                var meetsFilters = game.Id == match.Id;
+                if (global::ApolloSync.ApolloSync.ShouldRemoveManagedGame(
+                        gameExistsInLibrary: true,
+                        isPinned: pinned.Contains(game.Id),
+                        meetsFilters: meetsFilters,
+                        filterEvaluationFailed: false))
                 {
-                    toRemoveGames.Add(gameId);
-                    var app = apps.OfType<JObject>().FirstOrDefault(a => Guid.TryParse((string)a["uuid"], out var u) && u == appUuid);
-                    if (app != null) toRemoveApps.Add(app);
+                    Assert.IsTrue(sync.Remove(config, store, game));
                 }
             }
-            foreach (var a in toRemoveApps) { apps.Remove(a); removedCount++; }
-            foreach (var gid in toRemoveGames) { Guid _removedVal; store.GameToUuid.TryRemove(gid, out _removedVal); }
 
             // Assert
-            Assert.AreEqual(1, removedCount);
+            var apps = (JArray)config["apps"];
             Assert.AreEqual(1, apps.Count);
-            Assert.IsTrue(store.GameToUuid.ContainsKey(g1.Id));
-            Assert.IsFalse(store.GameToUuid.ContainsKey(g2.Id));
+            Assert.AreEqual("Match", (string)((JObject)apps[0])["name"]);
+            Assert.IsTrue(store.GameToUuid.ContainsKey(match.Id));
+            Assert.IsFalse(store.GameToUuid.ContainsKey(noMatch.Id));
+        }
+
+        // ── ManuallyRemoved round-trip ────────────────────────────────────────────
+
+        [TestMethod]
+        public void ManagedStore_ManuallyRemoved_RoundTripsThroughSettingsProjection()
+        {
+            // Mirrors LoadManagedStore/SaveManagedStore, which project the store to and from
+            // plugin settings. The manual-removal record must survive a restart — inferring it
+            // from "missing from apps.json" is what made the feature dead.
+            var store = new ManagedStore();
+            var kept = Guid.NewGuid();
+            var removed = Guid.NewGuid();
+            store.GameToUuid[kept] = Guid.NewGuid();
+            store.MarkManuallyRemoved(removed);
+
+            var mappings = new Dictionary<Guid, Guid>(store.GameToUuid);
+            var manuallyRemoved = store.ManuallyRemovedSnapshot();
+
+            var reloaded = new ManagedStore
+            {
+                GameToUuid = new System.Collections.Concurrent.ConcurrentDictionary<Guid, Guid>(mappings)
+            };
+            reloaded.ResetManuallyRemoved(manuallyRemoved);
+
+            Assert.IsTrue(reloaded.GameToUuid.ContainsKey(kept));
+            Assert.IsTrue(reloaded.IsManuallyRemoved(removed));
+            Assert.IsFalse(reloaded.IsManuallyRemoved(kept));
+        }
+
+        [TestMethod]
+        public void ManagedStore_ClearManualRemoval_AllowsGameToBeExportedAgain()
+        {
+            var store = new ManagedStore();
+            var id = Guid.NewGuid();
+
+            store.MarkManuallyRemoved(id);
+            Assert.IsTrue(store.IsManuallyRemoved(id));
+
+            store.ClearManualRemoval(id);
+            Assert.IsFalse(store.IsManuallyRemoved(id));
+        }
+
+        [TestMethod]
+        public void ManagedStore_ResetManuallyRemoved_HandlesNullAndReplacesContents()
+        {
+            var store = new ManagedStore();
+            var stale = Guid.NewGuid();
+            var fresh = Guid.NewGuid();
+
+            store.MarkManuallyRemoved(stale);
+            store.ResetManuallyRemoved(new[] { fresh });
+
+            Assert.IsFalse(store.IsManuallyRemoved(stale), "Reset should replace, not merge");
+            Assert.IsTrue(store.IsManuallyRemoved(fresh));
+
+            // LoadManagedStore passes the settings list straight through, which may be null.
+            store.ResetManuallyRemoved(null);
+            Assert.AreEqual(0, store.ManuallyRemovedCount);
+        }
+
+        [TestMethod]
+        public void ManagedStore_ManuallyRemoved_SurvivesConcurrentReadsAndWrites()
+        {
+            // The sync thread calls IsManuallyRemoved outside _configLock while UI-thread
+            // handlers mark removals. A plain HashSet throws or returns garbage when a write
+            // resizes it mid-read.
+            var store = new ManagedStore();
+            var probe = Guid.NewGuid();
+            store.MarkManuallyRemoved(probe);
+
+            var error = (Exception)null;
+            var writer = new System.Threading.Thread(() =>
+            {
+                try
+                {
+                    for (var i = 0; i < 20000; i++)
+                    {
+                        store.MarkManuallyRemoved(Guid.NewGuid());
+                    }
+                }
+                catch (Exception ex) { error = ex; }
+            });
+
+            var reader = new System.Threading.Thread(() =>
+            {
+                try
+                {
+                    for (var i = 0; i < 20000; i++)
+                    {
+                        Assert.IsTrue(store.IsManuallyRemoved(probe));
+                    }
+                }
+                catch (Exception ex) { error = ex; }
+            });
+
+            writer.Start();
+            reader.Start();
+            writer.Join();
+            reader.Join();
+
+            Assert.IsNull(error, "Concurrent access threw: " + error);
+        }
+
+        // ── Write fallback path ───────────────────────────────────────────────────
+
+        [TestMethod]
+        public void CopyThroughTempFile_BacksUpPreviousContentsBeforeOverwriting()
+        {
+            // This is the path that actually runs for a Program Files install, where the
+            // directory is not writable and the atomic swap is unavailable.
+            var path = CreateTempFilePath();
+            File.WriteAllText(path, "{\"apps\":[{\"name\":\"Old\"}]}");
+
+            ConfigService.CopyThroughTempFile(path, Encoding.UTF8.GetBytes("{\"apps\":[{\"name\":\"New\"}]}"));
+
+            Assert.IsTrue(File.Exists(path + ".bak"), "Fallback write must leave a backup");
+            StringAssert.Contains(File.ReadAllText(path + ".bak"), "Old");
+            StringAssert.Contains(File.ReadAllText(path), "New");
+        }
+
+        [TestMethod]
+        public void CopyThroughTempFile_CreatesDestinationWhenMissing()
+        {
+            var path = CreateTempFilePath();
+            Assert.IsFalse(File.Exists(path));
+
+            ConfigService.CopyThroughTempFile(path, Encoding.UTF8.GetBytes("{\"apps\":[]}"));
+
+            Assert.IsTrue(File.Exists(path));
+            Assert.IsFalse(File.Exists(path + ".bak"), "Nothing to back up when the file did not exist");
+        }
+
+        [TestMethod]
+        public void GetFallbackBackupPath_IsDistinctPerConfigAndAValidFileName()
+        {
+            var apollo = ConfigService.GetFallbackBackupPath(@"C:\Program Files\Apollo\config\apps.json");
+            var sunshine = ConfigService.GetFallbackBackupPath(@"C:\Program Files\Sunshine\config\apps.json");
+
+            Assert.AreNotEqual(apollo, sunshine, "Apollo and Sunshine backups must not collide");
+            CollectionAssert.DoesNotContain(Path.GetInvalidFileNameChars(), Path.GetFileName(apollo).ToCharArray()[0]);
+            foreach (var c in Path.GetInvalidFileNameChars())
+            {
+                Assert.IsFalse(Path.GetFileName(apollo).Contains(c.ToString()), "Backup file name must be valid");
+            }
         }
 
         // ── IsLocalAbsolutePath ───────────────────────────────────────────────────

--- a/Tests/AppsJsonManagementTests.cs
+++ b/Tests/AppsJsonManagementTests.cs
@@ -307,6 +307,51 @@ namespace ApolloSync.Tests
             Assert.IsNull(error, "Concurrent access threw: " + error);
         }
 
+        [TestMethod]
+        public void ManualRemoval_SurvivesAnExportWhoseSaveFails()
+        {
+            // Regression: ExportGamesWithFeedback used to clear the manual-removal record inside
+            // the per-game loop, before the batch SaveAppsConfig. If that write threw, the record
+            // was gone for the rest of the session even though apps.json never changed, so the
+            // next cover-image change or sync silently re-added the game.
+            //
+            // Mirrors the production ordering: mutate in memory, then only clear the records
+            // after the write succeeds.
+            var store = new ManagedStore();
+            var sync = new SyncService();
+            var config = new JObject { ["apps"] = new JArray() };
+            var game = new Game("Previously Removed") { Id = Guid.NewGuid(), InstallDirectory = "C:\\P" };
+
+            store.MarkManuallyRemoved(game.Id);
+
+            var exported = new List<Guid>();
+            Assert.IsTrue(sync.AddOrUpdate(config, store, game));
+            exported.Add(game.Id);
+
+            // The write fails.
+            var saveSucceeded = false;
+            try
+            {
+                throw new UnauthorizedAccessException("apps.json is not writable");
+            }
+            catch (UnauthorizedAccessException)
+            {
+                saveSucceeded = false;
+            }
+
+            if (saveSucceeded)
+            {
+                foreach (var id in exported) store.ClearManualRemoval(id);
+            }
+
+            Assert.IsTrue(store.IsManuallyRemoved(game.Id),
+                "A failed export must not drop the manual-removal protection");
+
+            // And once a write does succeed, the protection is correctly lifted.
+            foreach (var id in exported) store.ClearManualRemoval(id);
+            Assert.IsFalse(store.IsManuallyRemoved(game.Id));
+        }
+
         // ── Write fallback path ───────────────────────────────────────────────────
 
         [TestMethod]

--- a/extension.yaml
+++ b/extension.yaml
@@ -1,7 +1,7 @@
 Id: ApolloSync_f987343d-4168-4f44-9fb0-e3a21da314ad
 Name: ApolloSync
 Author: sharkusmanch
-Version: 1.2.1
+Version: 1.3.0
 Module: ApolloSync.dll
 Type: GenericPlugin
 Icon: icon.png

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,5 +1,18 @@
 AddonId: ApolloSync_f987343d-4168-4f44-9fb0-e3a21da314ad
 Packages:
+  - Version: 1.3.0
+    RequiredApiVersion: 6.16.0
+    ReleaseDate: 2026-07-26
+    PackageUrl: https://github.com/sharkusmanch/playnite-apollo-sync/releases/download/v1.3.0/ApolloSync_v1.3.0.pext
+    Changelog:
+      - Security - the permission fix no longer grants all local users write access to apps.json; only your own account is granted access
+      - apps.json writes are now atomic where possible and always keep a .bak of the previous contents
+      - Failed apps.json writes are no longer reported as success, and no longer leave orphaned entries behind
+      - Games you remove by hand stay removed - the manual removal is now recorded explicitly and survives a restart
+      - Removing games from the settings tab now removes them from apps.json too, instead of orphaning the entries
+      - A filter preset that fails to evaluate no longer causes every unpinned game to be removed
+      - The managed games list in settings now populates when the tab is opened instead of requiring a manual Refresh
+      - Removed the non-functional platform, label, completion status and category filter sections; use Playnite filter presets instead
   - Version: 1.2.1
     RequiredApiVersion: 6.16.0
     ReleaseDate: 2026-04-22

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,13 @@
   "extends": [
     "config:recommended"
   ],
-  "ignoreDeps": [
-    "Newtonsoft.Json"
+  "packageRules": [
+    {
+      "description": "Newtonsoft.Json is pinned to 10.0.3 to match the assembly Playnite loads at runtime. The reference is ExcludeAssets=runtime, so the plugin binds to Playnite's copy; compiling against a newer version risks a MethodNotFound at load time inside Playnite's AppDomain. Do not bump without verifying what Playnite ships.",
+      "matchPackageNames": [
+        "Newtonsoft.Json"
+      ],
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
Addresses the apollo-sync findings from the July 2026 code review, plus one user-reported bug and the open Renovate PRs.

Release **1.3.0** — `extension.yaml`, `manifest.yaml` (with changelog) and `AssemblyInfo.cs` all bumped and consistent.

## Security

**`claude.yml` had no author gate.** Any GitHub user could open an issue containing `@claude` and spend `CLAUDE_CODE_OAUTH_TOKEN`. The sibling `claude-code-review.yml` already gated on `comment.user.login`; this file did not. Now gated on `github.actor`.

**The permission fix granted `BUILTIN\Users:(M)` on `apps.json`** (`ApolloSync.cs:1334`). The Apollo/Sunshine service executes the `cmd` values in that file, so any unprivileged local account had code execution in the service's context. The ACL was never reverted and the consent prompt didn't disclose it. Now grants only `WindowsIdentity.GetCurrent().User`, and the prompt explains what the change does — translated into all 19 locales, since a consent dialog shouldn't be English-only.

## Data integrity

**The write documented as atomic was `File.Copy(overwrite: true)`** — truncate-and-rewrite in place, no backup, temp stream never `Flush(true)`-ed. Now prefers a same-directory temp + `File.Replace` (atomic, keeps a `.bak`), falling back to the copy path when the install directory isn't writable.

Worth being precise about the limit here: `TryFixFilePermissionsWithElevation` grants modify on the *file*, not the directory, so **a default Program Files install always takes the non-atomic fallback**. What that path now guarantees is a backup — taken once *before* the retry loop (taking it inside would let attempt 2 copy a half-written destination over the only good copy), falling back to `%LOCALAPPDATA%\ApolloSync\backups\` when the install directory is read-only. Documented as such in CLAUDE.md rather than claimed as atomic.

**`SaveAppsConfig` swallowed every exception**, making all four callers' `catch` blocks unreachable and letting `SaveManagedStore()` run after a failed write — leaving entries in `apps.json` the plugin no longer tracked, with nothing to ever clean them up. It now propagates; every caller was checked to confirm it skips the store save.

## Removal correctness

Three paths deleted or orphaned the wrong things:

- **A filter preset that threw was reported as "does not match"**, which `RemoveFilteredOutGames` read as "delete" — one transient failure wiped every unpinned managed game. Evaluation failure is now distinct from a non-match, encoded in a pure `ShouldRemoveManagedGame(gameExists, isPinned, meetsFilters, filterEvaluationFailed)`.
- **`RemoveGamesFromManaged` dropped store entries without touching `apps.json`**, orphaning them. It now removes from both sides, cancels any in-flight sync first (a background sync loads `apps.json`, works outside the lock, then saves its own snapshot — which would write the deleted entries straight back), and runs off the UI thread so it can't deadlock against the permission prompt it may trigger.
- **Manual removal was inferred from "in the store but missing from `apps.json`"** — precisely what `SyncManagedStore()` prunes at startup, so the inference was always false after a restart and removed games were silently re-added. Now recorded explicitly in `ManagedStore.ManuallyRemoved`, and honored by the automatic install / cover-update triggers so they can't resurrect a removed game either.

## Bug fix

**The managed games list in settings stayed empty until Refresh was clicked.** `FindChild` walks the visual tree, but a `TabItem`'s content isn't realized until the tab is selected — and Manage Games is the third tab, so the `Loaded` handler found nothing. The call in `BuildManageGamesTab` was also a no-op, since Playnite hasn't assigned the `DataContext` at construction time. Both population attempts silently failed; only the button worked. Now held by direct reference.

## Cleanup

- Removed ~250 lines of permanently `Visibility.Collapsed` filter UI bound to settings properties that never existed (`LabelOptions`, `Settings.RequiredLabelId`, …), plus the orphaned localization keys across 19 files and the dead `LabelOption` / `CompletionStatusOption`. Playnite filter presets already cover platform/category/completion.
- `CLAUDE.md` corrected: the write was documented as atomic, the `ManagedStore` description named a "manually removed set" that didn't exist, and the `MSBuild.exe` mandate is stale — `dotnet build` **does** generate `Settings/ApolloSyncSettingsView.g.cs` on net462 (verified on a clean build). MSBuild from a BuildTools-only install actually fails to resolve `Microsoft.NET.Sdk.WindowsDesktop`.
- `README` corrected: it advertised platform/label/completion/category filters that never shipped, and "only touches entries it created" understated `DeduplicateApps`, which upper-cases UUIDs on all entries, moves no-UUID entries to the end, and drops non-object array elements.
- `AssemblyInfo` tracked `1.0.0.0` against a `1.2.1` release. Now bumped by the bump workflow and enforced in `pull_request.yml`.
- Documented the deliberate Newtonsoft 10.0.3 pin in `renovate.json` (it's `ExcludeAssets=runtime` and must match what Playnite loads).
- Dropped the unused Playnite download from `pull_request.yml` (only the release job needs Toolbox.exe, and its `Playnite*.zip` glob matches no current asset), gated `release.yml` on tests, and replaced the unpinned `mikefarah/yq@master`.

## Renovate

Folded in and verified green: **#17** release-downloader v1.13, **#21** artifact actions v7/v8, **#24** Test.Sdk 18.8.1, **#25** checkout v7, **#27** MSTest 4.3.2. These should close as superseded.

## Verification

`dotnet build -c Release` clean (0 errors), **46/46 tests pass** (was 32).

`AppsJsonManagementTests` previously reimplemented the removal loop inline rather than calling it, so the real method was untested. It now exercises production code, with new coverage for the filter-failure path, the manual-removal lifecycle, concurrent access to the removal set, and the non-atomic write fallback that actually runs in production.

An adversarial review pass over this branch caught eight defects before it was opened — including three regressions introduced by the fixes themselves (removing a never-exported game would have blacklisted it forever; the settings-tab removal raced the background sync; the install/cover-update triggers re-added removed games). All are fixed here.

## Not addressed

PR #26 (`sync-by-tags`) is a separate feature branch and will likely conflict with the dead-UI removal.
