### PR TITLE
Prune managed games when filters no longer match

### DIFF
--- a/ApolloSync.cs
+++ b/ApolloSync.cs
@@ -523,33 +523,56 @@ namespace ApolloSync
         #endregion
 
         #region Game Filtering
+        /// <summary>
+        /// Snapshots the selected preset ids. The settings view edits
+        /// <see cref="ApolloSyncSettings.IncludedFilterPresetIds"/> in place on the UI thread as
+        /// the user ticks boxes — before OK is pressed, and undone only in memory by CancelEdit —
+        /// so a sync reading the live list can enumerate it mid-mutation, or observe a transient
+        /// empty list and prune everything the user was about to re-select.
+        /// </summary>
+        private List<Guid> SnapshotSelectedPresetIds()
+        {
+            var selected = _settings.Settings.IncludedFilterPresetIds;
+            return selected == null ? new List<Guid>() : new List<Guid>(selected);
+        }
+
         private List<Game> GetFilteredGames()
         {
+            return GetFilteredGames(SnapshotSelectedPresetIds());
+        }
+
+        private List<Game> GetFilteredGames(List<Guid> selectedPresetIds)
+        {
             // Use filter presets with OR logic - game matches if it matches ANY selected preset
-            if (_settings.Settings.IncludedFilterPresetIds?.Count > 0)
+            if (selectedPresetIds.Count > 0)
             {
                 var matchingGames = new HashSet<Game>();
 
-                foreach (var presetId in _settings.Settings.IncludedFilterPresetIds)
+                foreach (var presetId in selectedPresetIds)
                 {
                     var filterPreset = PlayniteApi.Database.FilterPresets
                         .FirstOrDefault(fp => fp.Id == presetId);
 
-                    if (filterPreset?.Settings != null)
+                    if (filterPreset?.Settings == null)
                     {
-                        try
+                        // Logged once per sync here rather than in GameMeetsCurrentFilters, which
+                        // now runs per managed game per sync and would emit this hundreds of times.
+                        logger.Warn($"Selected filter preset {presetId} no longer exists - it was probably deleted in Playnite. No games will be removed while it is missing.");
+                        continue;
+                    }
+
+                    try
+                    {
+                        var presetGames = PlayniteApi.Database.GetFilteredGames(filterPreset.Settings);
+                        foreach (var game in presetGames)
                         {
-                            var presetGames = PlayniteApi.Database.GetFilteredGames(filterPreset.Settings);
-                            foreach (var game in presetGames)
-                            {
-                                matchingGames.Add(game);
-                            }
-                            logger.Debug($"Filter preset '{filterPreset.Name}' matched {presetGames.Count()} games");
+                            matchingGames.Add(game);
                         }
-                        catch (Exception ex)
-                        {
-                            logger.Error(ex, $"Failed to apply filter preset: {filterPreset.Name}");
-                        }
+                        logger.Debug($"Filter preset '{filterPreset.Name}' matched {presetGames.Count()} games");
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.Error(ex, $"Failed to apply filter preset: {filterPreset.Name}");
                     }
                 }
 
@@ -565,75 +588,89 @@ namespace ApolloSync
         private bool GameMeetsCurrentFilters(Game game)
         {
             bool evaluationFailed;
-            return GameMeetsCurrentFilters(game, out evaluationFailed);
+            return GameMeetsCurrentFilters(game, SnapshotSelectedPresetIds(), out evaluationFailed);
         }
 
         /// <summary>
-        /// Distinguishes "the user selected nothing" from "a preset the user selected has gone
-        /// missing". Selecting nothing is a deliberate export-nothing, so pruning is correct. A
-        /// selected id that no longer resolves means the preset was deleted or recreated in
-        /// Playnite (recreating assigns a new id, and nothing prunes the stale one from settings),
-        /// and we cannot tell what it used to match — so no removal decision can be made.
-        /// Kept pure so the distinction is directly testable.
+        /// Applies the OR-across-presets rule. <paramref name="matchPreset"/> returns null when an
+        /// id does not resolve to a usable preset, and may throw if the evaluation itself fails.
+        /// Both mean "could not determine", and both set <paramref name="evaluationFailed"/> —
+        /// callers that delete on a false result must check it, or a deleted preset or one
+        /// transient failure wipes every non-pinned managed entry.
+        ///
+        /// An empty selection is different: it is a deliberate "export nothing", so it returns
+        /// false with no failure flagged and pruning proceeds.
+        ///
+        /// Pure apart from the delegate, so all of this is directly testable without Playnite.
         /// </summary>
-        internal static bool FilterPresetsAreEvaluable(int selectedPresetCount, int resolvedPresetCount)
-        {
-            return selectedPresetCount == resolvedPresetCount;
-        }
-
-        /// <summary>
-        /// Evaluates the game against the selected filter presets (OR logic).
-        /// <paramref name="evaluationFailed"/> is set when a preset could not be evaluated at all,
-        /// which is not the same as "did not match" — callers that delete on a false result must
-        /// check it, or one transient failure wipes every non-pinned managed entry.
-        /// </summary>
-        private bool GameMeetsCurrentFilters(Game game, out bool evaluationFailed)
+        internal static bool EvaluateFilterPresets(
+            IList<Guid> selectedPresetIds,
+            Func<Guid, bool?> matchPreset,
+            out bool evaluationFailed)
         {
             evaluationFailed = false;
 
-            // Use filter presets with OR logic - game matches if it matches ANY selected preset
-            var selectedPresetIds = _settings.Settings.IncludedFilterPresetIds;
-            if (selectedPresetIds?.Count > 0)
+            if (selectedPresetIds == null || selectedPresetIds.Count == 0)
             {
-                var resolvedPresets = 0;
+                return false;
+            }
 
-                foreach (var presetId in selectedPresetIds)
+            var unresolved = 0;
+
+            foreach (var presetId in selectedPresetIds)
+            {
+                bool? matched;
+                try
                 {
-                    var filterPreset = PlayniteApi.Database.FilterPresets
-                        .FirstOrDefault(fp => fp.Id == presetId);
-
-                    if (filterPreset?.Settings == null)
-                    {
-                        logger.Warn($"Selected filter preset {presetId} no longer exists - cannot evaluate it");
-                        continue;
-                    }
-
-                    resolvedPresets++;
-
-                    try
-                    {
-                        if (PlayniteApi.Database.GetGameMatchesFilter(game, filterPreset.Settings))
-                        {
-                            return true; // Match found, return true immediately
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        evaluationFailed = true;
-                        logger.Error(ex, $"Failed to check game against filter preset: {filterPreset.Name}");
-                    }
+                    matched = matchPreset(presetId);
                 }
-
-                if (!FilterPresetsAreEvaluable(selectedPresetIds.Count, resolvedPresets))
+                catch (Exception ex)
                 {
                     evaluationFailed = true;
+                    logger.Error(ex, $"Failed to check game against filter preset {presetId}");
+                    continue;
+                }
+
+                if (matched == null)
+                {
+                    unresolved++;
+                    continue;
+                }
+
+                if (matched.Value)
+                {
+                    // A match is a match — the caller keeps the game either way, so whether the
+                    // remaining presets were evaluable cannot change the outcome.
+                    return true;
                 }
             }
 
-            // No filter presets selected or no matches found
+            if (unresolved > 0)
+            {
+                evaluationFailed = true;
+            }
+
             return false;
+        }
 
+        /// <summary>
+        /// Evaluates the game against the given filter presets (OR logic). Takes the ids as a
+        /// snapshot rather than reading settings directly — see <see cref="SnapshotSelectedPresetIds"/>.
+        /// </summary>
+        private bool GameMeetsCurrentFilters(Game game, IList<Guid> selectedPresetIds, out bool evaluationFailed)
+        {
+            return EvaluateFilterPresets(selectedPresetIds, presetId =>
+            {
+                var filterPreset = PlayniteApi.Database.FilterPresets
+                    .FirstOrDefault(fp => fp.Id == presetId);
 
+                if (filterPreset?.Settings == null)
+                {
+                    return null; // Deleted in Playnite — cannot say what it used to match.
+                }
+
+                return PlayniteApi.Database.GetGameMatchesFilter(game, filterPreset.Settings);
+            }, out evaluationFailed);
         }
 
         /// <summary>
@@ -662,29 +699,54 @@ namespace ApolloSync
         }
 
         /// <summary>
+        /// Deletes the given games' entries from <paramref name="config"/> and returns the ids the
+        /// caller must disown. An id is returned even when no matching entry existed — that game
+        /// is an orphan and the store should stop claiming it either way, and the caller relies on
+        /// the count to know a save is needed. Entries this extension does not own are never
+        /// touched: matching is by the store's recorded UUID only.
+        /// Pure — no Playnite database access — so the apps.json surgery is directly testable.
+        /// </summary>
+        internal static List<Guid> ApplyRemovals(JObject config, IEnumerable<KeyValuePair<Guid, Guid>> gamesToRemove)
+        {
+            var removed = new List<Guid>();
+            var apps = config["apps"] as JArray;
+
+            foreach (var entry in gamesToRemove)
+            {
+                if (apps != null)
+                {
+                    var appToRemove = apps.OfType<JObject>().FirstOrDefault(app =>
+                        Guid.TryParse((string)app["uuid"], out var uuid) && uuid == entry.Value);
+                    if (appToRemove != null)
+                    {
+                        apps.Remove(appToRemove);
+                    }
+                }
+
+                removed.Add(entry.Key);
+            }
+
+            return removed;
+        }
+
+        /// <summary>
         /// Drops filtered-out games from <paramref name="config"/> and returns the game ids whose
         /// managed-store entries should go with them. The store is deliberately NOT mutated here:
         /// the caller applies the returned ids only once the write to disk has succeeded, so a
         /// failed write cannot leave the in-memory store disowning entries that are still in
         /// apps.json. Same ordering rule as ExportGamesWithFeedback.
         /// </summary>
-        private List<Guid> RemoveFilteredOutGames(JObject config, HashSet<Guid> pinnedGameIds = null)
+        private List<Guid> RemoveFilteredOutGames(JObject config, HashSet<Guid> pinnedGameIds, IList<Guid> selectedPresetIds)
         {
-            // Every id here is one the caller must drop from the store, including games whose
-            // apps.json entry was already missing — those are orphans and the store should stop
-            // claiming them either way.
-            var gamesToUnmanage = new List<Guid>();
             var pinned = pinnedGameIds ?? new HashSet<Guid>(_settings.Settings.PinnedGameIds);
+            var gamesToRemove = new List<KeyValuePair<Guid, Guid>>();
 
             try
             {
-                var apps = (JArray)(config["apps"] ?? new JArray());
-
                 // Check each managed game
                 foreach (var gameEntry in _managedStore.GameToUuid.ToList())
                 {
                     var gameId = gameEntry.Key;
-                    var appUuid = gameEntry.Value;
 
                     // Get the game from database
                     var game = PlayniteApi.Database.Games.Get(gameId);
@@ -693,7 +755,7 @@ namespace ApolloSync
                     var filterEvaluationFailed = false;
                     if (game != null)
                     {
-                        meetsFilters = GameMeetsCurrentFilters(game, out filterEvaluationFailed);
+                        meetsFilters = GameMeetsCurrentFilters(game, selectedPresetIds, out filterEvaluationFailed);
                     }
 
                     if (!ShouldRemoveManagedGame(game != null, pinned.Contains(gameId), meetsFilters, filterEvaluationFailed))
@@ -708,27 +770,48 @@ namespace ApolloSync
                     logger.Info(game == null
                         ? $"Removing game {gameId} - no longer exists in database"
                         : $"Removing game {game.Name} - no longer meets filters (not pinned)");
-
-                    // Removed from the config immediately rather than batched afterwards: if
-                    // anything below throws, the ids already returned must be exactly the ones
-                    // whose app entries are actually gone.
-                    var appToRemove = apps.OfType<JObject>().FirstOrDefault(app =>
-                        Guid.TryParse((string)app["uuid"], out var uuid) && uuid == appUuid);
-                    if (appToRemove != null)
-                    {
-                        apps.Remove(appToRemove);
-                    }
-
-                    gamesToUnmanage.Add(gameId);
+                    gamesToRemove.Add(gameEntry);
                 }
 
+                var gamesToUnmanage = ApplyRemovals(config, gamesToRemove);
                 logger.Info($"RemoveFilteredOutGames completed: {gamesToUnmanage.Count} games to drop from apps.json and the managed store");
                 return gamesToUnmanage;
             }
             catch (Exception ex)
             {
+                // The decision loop threw, so nothing has been applied to the config yet and
+                // there is nothing for the caller to disown.
                 logger.Error(ex, "Error in RemoveFilteredOutGames");
-                return gamesToUnmanage;
+                return new List<Guid>();
+            }
+        }
+
+        /// <summary>
+        /// Removes ids that the add/update phase put back. Phase 1 decides removals against a
+        /// freshly re-evaluated library while the add/update set was snapshotted earlier, so the
+        /// two can disagree — a game deleted from Playnite mid-sync, say. Disowning a game whose
+        /// entry Phase 2 just rewrote would strand that entry in apps.json with nothing tracking
+        /// it, and SyncManagedStore only prunes the opposite direction, so a restart cannot
+        /// recover it.
+        /// </summary>
+        internal static List<Guid> ExcludeReAddedGames(IEnumerable<Guid> gamesToUnmanage, ICollection<Guid> reAddedGameIds)
+        {
+            return gamesToUnmanage.Where(id => !reAddedGameIds.Contains(id)).ToList();
+        }
+
+        /// <summary>
+        /// Writes the config and only then disowns the games, so a failed write leaves the store
+        /// matching the apps.json that is still on disk. Kept separate from the sync body so the
+        /// ordering itself can be tested with a save that throws.
+        /// </summary>
+        internal static void SaveThenDisown(Action save, ManagedStore store, IEnumerable<Guid> gamesToUnmanage)
+        {
+            save();
+
+            foreach (var gameId in gamesToUnmanage)
+            {
+                Guid removedUuid;
+                store.GameToUuid.TryRemove(gameId, out removedUuid);
             }
         }
         #endregion
@@ -786,11 +869,15 @@ namespace ApolloSync
         {
             logger.Info("Starting sync filtered games operation");
 
+            // One snapshot for the whole sync: both phases must agree on which presets were
+            // selected, and the live list can change under us while the settings view is open.
+            var selectedPresetIds = SnapshotSelectedPresetIds();
+
             // Deliberately no early return when nothing matches. Unchecking a preset is how the
             // user says "stop exporting these", and it is the removal phase below — not the
             // add/update phase — that carries it out. Returning here left the games in apps.json
             // until something else happened to match again.
-            var filteredGames = GetFilteredGames();
+            var filteredGames = GetFilteredGames(selectedPresetIds);
             logger.Info($"Found {filteredGames.Count} games matching filter presets to sync");
 
             var localSuccess = 0;
@@ -820,9 +907,11 @@ namespace ApolloSync
 
             logger.Info($"Starting batch sync operation with {filteredGames.Count} games");
 
-            // Removal is the destructive half and no longer sits behind an early return, so it
-            // must honour cancellation too. Without this, a sync cancelled at shutdown could
-            // still commit a net-destructive apps.json: removals applied, additions skipped.
+            // Removal is the destructive half and no longer sits behind an early return, so a
+            // sync that is already cancelled must not start it. Note this only covers the window
+            // before Phase 1: cancelling later still commits whatever both phases completed,
+            // which is correct — the removals are valid and the missing additions are redone by
+            // the next sync.
             if (cancellationToken.IsCancellationRequested)
             {
                 logger.Info("Sync cancelled by user before removal phase");
@@ -831,11 +920,12 @@ namespace ApolloSync
 
             // Phase 1: Remove managed games that no longer meet filters (unless pinned). The
             // store entries are dropped further down, once the write has actually landed.
-            var gamesToUnmanage = RemoveFilteredOutGames(config, pinnedSnapshot);
+            var gamesToUnmanage = RemoveFilteredOutGames(config, pinnedSnapshot, selectedPresetIds);
             localRemoved = gamesToUnmanage.Count;
             logger.Info($"Removed {localRemoved} games that no longer meet filters");
 
             // Phase 2: Add/update games that meet current filters
+            var reAddedGameIds = new HashSet<Guid>();
             for (int i = 0; i < filteredGames.Count; i++)
             {
                 if (cancellationToken.IsCancellationRequested)
@@ -860,6 +950,7 @@ namespace ApolloSync
                     if (TryAddOrUpdateAppBatch(game, config))
                     {
                         localSuccess++;
+                        reAddedGameIds.Add(game.Id);
                         logger.Debug($"Successfully processed: {game.Name}");
                     }
                     else
@@ -881,15 +972,20 @@ namespace ApolloSync
 
             if (filteredGames.Count == 0 && localRemoved == 0)
             {
-                // Still worth surfacing — an empty result with nothing to clean up is usually a
-                // misconfiguration. Suppressed when the sync did remove something, because that
-                // is the user unchecking their last preset on purpose; the completion
-                // notification below already reports it, and an error here would be wrong.
+                // Nothing matched and there was nothing to clean up, which is usually a
+                // misconfiguration. Returning here also keeps this to a single notification —
+                // there is nothing to save, and the completion notification would only add a
+                // contradictory "0 succeeded, 0 failed" beside it.
                 ShowNotificationIfEnabled(new NotificationMessage(
                     "apollosync-no-games",
                     "No games match the selected filter presets. Please check your filter preset configuration.",
                     NotificationType.Error), isUpdateOperation: true);
+                return;
             }
+
+            // A game the add/update phase restored must keep its store entry, or its apps.json
+            // entry is stranded with nothing tracking it.
+            gamesToUnmanage = ExcludeReAddedGames(gamesToUnmanage, reAddedGameIds);
 
             // Save everything once at the end
             if (localSuccess > 0 || localRemoved > 0)
@@ -899,18 +995,11 @@ namespace ApolloSync
                 {
                     try
                     {
-                        SaveAppsConfig(config);
-
-                        // Only now disown the removed games. If the write above threw, the store
-                        // still matches the unchanged apps.json; dropping them earlier would
-                        // strand their entries there with nothing tracking them, invisible to
-                        // both the Manage Games list and every later sync, until a restart.
-                        foreach (var gameId in gamesToUnmanage)
-                        {
-                            Guid removedUuid;
-                            _managedStore.GameToUuid.TryRemove(gameId, out removedUuid);
-                        }
-
+                        // Disown only after the write lands. If it throws, the store still
+                        // matches the unchanged apps.json; dropping them earlier would strand
+                        // their entries there with nothing tracking them, invisible to both the
+                        // Manage Games list and every later sync, until a restart.
+                        SaveThenDisown(() => SaveAppsConfig(config), _managedStore, gamesToUnmanage);
                         SaveManagedStore();
                         logger.Info("Batch save completed successfully");
                     }

--- a/ApolloSync.cs
+++ b/ApolloSync.cs
@@ -763,16 +763,11 @@ namespace ApolloSync
         {
             logger.Info("Starting sync filtered games operation");
 
+            // Deliberately no early return when nothing matches. Unchecking a preset is how the
+            // user says "stop exporting these", and it is the removal phase below — not the
+            // add/update phase — that carries it out. Returning here left the games in apps.json
+            // until something else happened to match again.
             var filteredGames = GetFilteredGames();
-            if (filteredGames.Count == 0)
-            {
-                ShowNotificationIfEnabled(new NotificationMessage(
-                    "apollosync-no-games",
-                    "No games match the selected filter presets. Please check your filter preset configuration.",
-                    NotificationType.Error), isUpdateOperation: true);
-                return;
-            }
-
             logger.Info($"Found {filteredGames.Count} games matching filter presets to sync");
 
             var localSuccess = 0;
@@ -802,7 +797,7 @@ namespace ApolloSync
 
             logger.Info($"Starting batch sync operation with {filteredGames.Count} games");
 
-            // Phase 1: Remove games that no longer meet filters (unless pinned)
+            // Phase 1: Remove managed games that no longer meet filters (unless pinned)
             var removedGames = RemoveFilteredOutGames(config, pinnedSnapshot);
             localRemoved = removedGames;
             logger.Info($"Removed {removedGames} games that no longer meet filters");
@@ -849,6 +844,16 @@ namespace ApolloSync
                     localErrors.Add(error);
                     logger.Error(ex, error);
                 }
+            }
+
+            if (filteredGames.Count == 0)
+            {
+                // Still worth surfacing — an empty result is usually a misconfiguration — but
+                // only after the removal above has been allowed to run.
+                ShowNotificationIfEnabled(new NotificationMessage(
+                    "apollosync-no-games",
+                    "No games match the selected filter presets. Please check your filter preset configuration.",
+                    NotificationType.Error), isUpdateOperation: true);
             }
 
             // Save everything once at the end

--- a/ApolloSync.cs
+++ b/ApolloSync.cs
@@ -569,6 +569,19 @@ namespace ApolloSync
         }
 
         /// <summary>
+        /// Distinguishes "the user selected nothing" from "a preset the user selected has gone
+        /// missing". Selecting nothing is a deliberate export-nothing, so pruning is correct. A
+        /// selected id that no longer resolves means the preset was deleted or recreated in
+        /// Playnite (recreating assigns a new id, and nothing prunes the stale one from settings),
+        /// and we cannot tell what it used to match — so no removal decision can be made.
+        /// Kept pure so the distinction is directly testable.
+        /// </summary>
+        internal static bool FilterPresetsAreEvaluable(int selectedPresetCount, int resolvedPresetCount)
+        {
+            return selectedPresetCount == resolvedPresetCount;
+        }
+
+        /// <summary>
         /// Evaluates the game against the selected filter presets (OR logic).
         /// <paramref name="evaluationFailed"/> is set when a preset could not be evaluated at all,
         /// which is not the same as "did not match" — callers that delete on a false result must
@@ -579,28 +592,41 @@ namespace ApolloSync
             evaluationFailed = false;
 
             // Use filter presets with OR logic - game matches if it matches ANY selected preset
-            if (_settings.Settings.IncludedFilterPresetIds?.Count > 0)
+            var selectedPresetIds = _settings.Settings.IncludedFilterPresetIds;
+            if (selectedPresetIds?.Count > 0)
             {
-                foreach (var presetId in _settings.Settings.IncludedFilterPresetIds)
+                var resolvedPresets = 0;
+
+                foreach (var presetId in selectedPresetIds)
                 {
                     var filterPreset = PlayniteApi.Database.FilterPresets
                         .FirstOrDefault(fp => fp.Id == presetId);
 
-                    if (filterPreset?.Settings != null)
+                    if (filterPreset?.Settings == null)
                     {
-                        try
+                        logger.Warn($"Selected filter preset {presetId} no longer exists - cannot evaluate it");
+                        continue;
+                    }
+
+                    resolvedPresets++;
+
+                    try
+                    {
+                        if (PlayniteApi.Database.GetGameMatchesFilter(game, filterPreset.Settings))
                         {
-                            if (PlayniteApi.Database.GetGameMatchesFilter(game, filterPreset.Settings))
-                            {
-                                return true; // Match found, return true immediately
-                            }
-                        }
-                        catch (Exception ex)
-                        {
-                            evaluationFailed = true;
-                            logger.Error(ex, $"Failed to check game against filter preset: {filterPreset.Name}");
+                            return true; // Match found, return true immediately
                         }
                     }
+                    catch (Exception ex)
+                    {
+                        evaluationFailed = true;
+                        logger.Error(ex, $"Failed to check game against filter preset: {filterPreset.Name}");
+                    }
+                }
+
+                if (!FilterPresetsAreEvaluable(selectedPresetIds.Count, resolvedPresets))
+                {
+                    evaluationFailed = true;
                 }
             }
 
@@ -797,6 +823,15 @@ namespace ApolloSync
 
             logger.Info($"Starting batch sync operation with {filteredGames.Count} games");
 
+            // Removal is the destructive half and no longer sits behind an early return, so it
+            // must honour cancellation too. Without this, a sync cancelled at shutdown could
+            // still commit a net-destructive apps.json: removals applied, additions skipped.
+            if (cancellationToken.IsCancellationRequested)
+            {
+                logger.Info("Sync cancelled by user before removal phase");
+                return;
+            }
+
             // Phase 1: Remove managed games that no longer meet filters (unless pinned)
             var removedGames = RemoveFilteredOutGames(config, pinnedSnapshot);
             localRemoved = removedGames;
@@ -846,10 +881,12 @@ namespace ApolloSync
                 }
             }
 
-            if (filteredGames.Count == 0)
+            if (filteredGames.Count == 0 && localRemoved == 0)
             {
-                // Still worth surfacing — an empty result is usually a misconfiguration — but
-                // only after the removal above has been allowed to run.
+                // Still worth surfacing — an empty result with nothing to clean up is usually a
+                // misconfiguration. Suppressed when the sync did remove something, because that
+                // is the user unchecking their last preset on purpose; the completion
+                // notification below already reports it, and an error here would be wrong.
                 ShowNotificationIfEnabled(new NotificationMessage(
                     "apollosync-no-games",
                     "No games match the selected filter presets. Please check your filter preset configuration.",

--- a/ApolloSync.cs
+++ b/ApolloSync.cs
@@ -661,16 +661,24 @@ namespace ApolloSync
             return !meetsFilters;
         }
 
-        private int RemoveFilteredOutGames(JObject config, HashSet<Guid> pinnedGameIds = null)
+        /// <summary>
+        /// Drops filtered-out games from <paramref name="config"/> and returns the game ids whose
+        /// managed-store entries should go with them. The store is deliberately NOT mutated here:
+        /// the caller applies the returned ids only once the write to disk has succeeded, so a
+        /// failed write cannot leave the in-memory store disowning entries that are still in
+        /// apps.json. Same ordering rule as ExportGamesWithFeedback.
+        /// </summary>
+        private List<Guid> RemoveFilteredOutGames(JObject config, HashSet<Guid> pinnedGameIds = null)
         {
-            var removedCount = 0;
+            // Every id here is one the caller must drop from the store, including games whose
+            // apps.json entry was already missing — those are orphans and the store should stop
+            // claiming them either way.
+            var gamesToUnmanage = new List<Guid>();
             var pinned = pinnedGameIds ?? new HashSet<Guid>(_settings.Settings.PinnedGameIds);
 
             try
             {
                 var apps = (JArray)(config["apps"] ?? new JArray());
-                var appsToRemove = new List<JObject>();
-                var managedGamesToRemove = new List<Guid>();
 
                 // Check each managed game
                 foreach (var gameEntry in _managedStore.GameToUuid.ToList())
@@ -700,38 +708,27 @@ namespace ApolloSync
                     logger.Info(game == null
                         ? $"Removing game {gameId} - no longer exists in database"
                         : $"Removing game {game.Name} - no longer meets filters (not pinned)");
-                    managedGamesToRemove.Add(gameId);
 
-                    // Find and mark app for removal
+                    // Removed from the config immediately rather than batched afterwards: if
+                    // anything below throws, the ids already returned must be exactly the ones
+                    // whose app entries are actually gone.
                     var appToRemove = apps.OfType<JObject>().FirstOrDefault(app =>
                         Guid.TryParse((string)app["uuid"], out var uuid) && uuid == appUuid);
                     if (appToRemove != null)
                     {
-                        appsToRemove.Add(appToRemove);
+                        apps.Remove(appToRemove);
                     }
+
+                    gamesToUnmanage.Add(gameId);
                 }
 
-                // Remove apps from config
-                foreach (var appToRemove in appsToRemove)
-                {
-                    apps.Remove(appToRemove);
-                    removedCount++;
-                }
-
-                // Remove from managed store
-                foreach (var gameId in managedGamesToRemove)
-                {
-                    Guid removedId;
-                    _managedStore.GameToUuid.TryRemove(gameId, out removedId);
-                }
-
-                logger.Info($"RemoveFilteredOutGames completed: removed {removedCount} games from apps.json");
-                return removedCount;
+                logger.Info($"RemoveFilteredOutGames completed: {gamesToUnmanage.Count} games to drop from apps.json and the managed store");
+                return gamesToUnmanage;
             }
             catch (Exception ex)
             {
                 logger.Error(ex, "Error in RemoveFilteredOutGames");
-                return removedCount;
+                return gamesToUnmanage;
             }
         }
         #endregion
@@ -832,10 +829,11 @@ namespace ApolloSync
                 return;
             }
 
-            // Phase 1: Remove managed games that no longer meet filters (unless pinned)
-            var removedGames = RemoveFilteredOutGames(config, pinnedSnapshot);
-            localRemoved = removedGames;
-            logger.Info($"Removed {removedGames} games that no longer meet filters");
+            // Phase 1: Remove managed games that no longer meet filters (unless pinned). The
+            // store entries are dropped further down, once the write has actually landed.
+            var gamesToUnmanage = RemoveFilteredOutGames(config, pinnedSnapshot);
+            localRemoved = gamesToUnmanage.Count;
+            logger.Info($"Removed {localRemoved} games that no longer meet filters");
 
             // Phase 2: Add/update games that meet current filters
             for (int i = 0; i < filteredGames.Count; i++)
@@ -902,6 +900,17 @@ namespace ApolloSync
                     try
                     {
                         SaveAppsConfig(config);
+
+                        // Only now disown the removed games. If the write above threw, the store
+                        // still matches the unchanged apps.json; dropping them earlier would
+                        // strand their entries there with nothing tracking them, invisible to
+                        // both the Manage Games list and every later sync, until a restart.
+                        foreach (var gameId in gamesToUnmanage)
+                        {
+                            Guid removedUuid;
+                            _managedStore.GameToUuid.TryRemove(gameId, out removedUuid);
+                        }
+
                         SaveManagedStore();
                         logger.Info("Batch save completed successfully");
                     }

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -35,5 +35,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 // Kept in step with extension.yaml by the bump workflow and enforced by pull_request.yml.
-[assembly: AssemblyVersion("1.3.0.0")]
-[assembly: AssemblyFileVersion("1.3.0.0")]
+[assembly: AssemblyVersion("1.3.1.0")]
+[assembly: AssemblyFileVersion("1.3.1.0")]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Playnite extension that syncs your game library to [Apollo](https://github.com
 ## Features
 
 - **Automatic sync** -- exports games matching your filters to Apollo/Sunshine's `apps.json` on install, library update, settings change, or Playnite startup (each individually configurable)
-- **Filter presets** -- uses your existing Playnite filter presets to decide what gets exported (OR logic when multiple are selected). Filter by platform, category, completion status or anything else by building the preset in Playnite's library view.
+- **Filter presets** -- uses your existing Playnite filter presets to decide what gets exported (OR logic when multiple are selected). Filter by tag, platform, category, completion status or anything else by building the preset in Playnite's library view. Unchecking a preset removes its games from `apps.json` on the next sync, unless they are pinned.
 - **Pin/unpin** -- pin games to prevent auto-removal even when they stop matching filters
 - **Manual export/remove** -- right-click context menu for individual games. A game you remove by hand stays removed; sync will not re-add it until you export it again.
 - **Manage exported games** -- view and manage all synced games from the settings tab

--- a/Tests/AppsJsonManagementTests.cs
+++ b/Tests/AppsJsonManagementTests.cs
@@ -166,70 +166,290 @@ namespace ApolloSync.Tests
                 gameExistsInLibrary: true, isPinned: false, meetsFilters: false, filterEvaluationFailed: true));
         }
 
-        // ── FilterPresetsAreEvaluable ─────────────────────────────────────────────
-        // Guards the case that made removal-on-every-sync dangerous: a selected preset id
-        // that no longer resolves reads as "matched nothing" unless it is caught here.
+        // ── EvaluateFilterPresets ─────────────────────────────────────────────────
+        // The safety interlock that makes "removal runs on every sync" survivable. The delegate
+        // stands in for the Playnite lookup: null means the id did not resolve, throwing means
+        // the evaluation itself failed. Both must read as "could not determine".
 
         [TestMethod]
-        public void FilterPresetsAreEvaluable_NoPresetsSelectedIsDeliberate()
+        public void EvaluateFilterPresets_MatchingPresetMeetsFilters()
         {
-            // Selecting nothing means "export nothing", so pruning must still be allowed.
-            Assert.IsTrue(global::ApolloSync.ApolloSync.FilterPresetsAreEvaluable(
-                selectedPresetCount: 0, resolvedPresetCount: 0));
+            bool failed;
+            var matched = global::ApolloSync.ApolloSync.EvaluateFilterPresets(
+                new List<Guid> { Guid.NewGuid() }, id => true, out failed);
+
+            Assert.IsTrue(matched);
+            Assert.IsFalse(failed);
         }
 
         [TestMethod]
-        public void FilterPresetsAreEvaluable_AllSelectedPresetsResolve()
+        public void EvaluateFilterPresets_NonMatchingPresetIsADefiniteNo()
         {
-            Assert.IsTrue(global::ApolloSync.ApolloSync.FilterPresetsAreEvaluable(
-                selectedPresetCount: 3, resolvedPresetCount: 3));
+            // The case that must stay prunable: the preset resolved, it just did not match.
+            bool failed;
+            var matched = global::ApolloSync.ApolloSync.EvaluateFilterPresets(
+                new List<Guid> { Guid.NewGuid() }, id => false, out failed);
+
+            Assert.IsFalse(matched);
+            Assert.IsFalse(failed);
+            Assert.IsTrue(global::ApolloSync.ApolloSync.ShouldRemoveManagedGame(
+                gameExistsInLibrary: true, isPinned: false, meetsFilters: matched, filterEvaluationFailed: failed));
         }
 
         [TestMethod]
-        public void FilterPresetsAreEvaluable_OneSelectedPresetWentMissing()
+        public void EvaluateFilterPresets_EmptySelectionIsDeliberateAndPrunes()
         {
-            Assert.IsFalse(global::ApolloSync.ApolloSync.FilterPresetsAreEvaluable(
-                selectedPresetCount: 3, resolvedPresetCount: 2));
+            // Unchecking everything means "export nothing" — the behaviour this branch delivers.
+            // It must NOT be confused with "could not determine".
+            bool failed;
+            var matched = global::ApolloSync.ApolloSync.EvaluateFilterPresets(
+                new List<Guid>(), id => true, out failed);
+
+            Assert.IsFalse(matched);
+            Assert.IsFalse(failed);
+            Assert.IsTrue(global::ApolloSync.ApolloSync.ShouldRemoveManagedGame(
+                gameExistsInLibrary: true, isPinned: false, meetsFilters: matched, filterEvaluationFailed: failed));
         }
 
         [TestMethod]
-        public void FilterPresetsAreEvaluable_EverySelectedPresetWentMissing()
-        {
-            Assert.IsFalse(global::ApolloSync.ApolloSync.FilterPresetsAreEvaluable(
-                selectedPresetCount: 2, resolvedPresetCount: 0));
-        }
-
-        [TestMethod]
-        public void DeletedFilterPreset_DoesNotRemoveManagedGames()
+        public void EvaluateFilterPresets_DeletedPresetBlocksRemoval()
         {
             // Regression: deleting a preset in Playnite (or deleting and recreating it, which
-            // assigns a new id) leaves a stale id in IncludedFilterPresetIds. That used to
-            // resolve to nothing, evaluate as "no match", and — now that removal runs on every
-            // sync rather than only when something matched — delete every non-pinned entry.
-            var evaluable = global::ApolloSync.ApolloSync.FilterPresetsAreEvaluable(
-                selectedPresetCount: 1, resolvedPresetCount: 0);
+            // assigns a new id) leaves a stale id in IncludedFilterPresetIds that resolves to
+            // nothing. Read as "did not match", it would delete every non-pinned managed game on
+            // the next automatic sync.
+            bool failed;
+            var matched = global::ApolloSync.ApolloSync.EvaluateFilterPresets(
+                new List<Guid> { Guid.NewGuid() }, id => null, out failed);
 
-            Assert.IsFalse(evaluable);
+            Assert.IsFalse(matched);
+            Assert.IsTrue(failed, "An unresolvable preset id must flag the evaluation as failed");
             Assert.IsFalse(global::ApolloSync.ApolloSync.ShouldRemoveManagedGame(
-                gameExistsInLibrary: true,
-                isPinned: false,
-                meetsFilters: false,
-                filterEvaluationFailed: !evaluable));
+                gameExistsInLibrary: true, isPinned: false, meetsFilters: matched, filterEvaluationFailed: failed));
         }
 
         [TestMethod]
-        public void ClearingEveryFilterPreset_StillRemovesManagedGames()
+        public void EvaluateFilterPresets_ThrowingPresetBlocksRemoval()
         {
-            // The behaviour this change exists to deliver: unchecking everything prunes.
-            var evaluable = global::ApolloSync.ApolloSync.FilterPresetsAreEvaluable(
-                selectedPresetCount: 0, resolvedPresetCount: 0);
+            bool failed;
+            var matched = global::ApolloSync.ApolloSync.EvaluateFilterPresets(
+                new List<Guid> { Guid.NewGuid() },
+                id => { throw new InvalidOperationException("preset blew up"); },
+                out failed);
 
-            Assert.IsTrue(evaluable);
-            Assert.IsTrue(global::ApolloSync.ApolloSync.ShouldRemoveManagedGame(
-                gameExistsInLibrary: true,
-                isPinned: false,
-                meetsFilters: false,
-                filterEvaluationFailed: !evaluable));
+            Assert.IsFalse(matched);
+            Assert.IsTrue(failed);
+        }
+
+        [TestMethod]
+        public void EvaluateFilterPresets_OneMissingPresetAmongWorkingOnesStillBlocksRemoval()
+        {
+            // Partial resolution is still "could not determine" — the missing preset may well be
+            // the one that used to match this game.
+            var missing = Guid.NewGuid();
+            var working = Guid.NewGuid();
+
+            bool failed;
+            var matched = global::ApolloSync.ApolloSync.EvaluateFilterPresets(
+                new List<Guid> { working, missing },
+                id => id == missing ? (bool?)null : false,
+                out failed);
+
+            Assert.IsFalse(matched);
+            Assert.IsTrue(failed);
+        }
+
+        [TestMethod]
+        public void EvaluateFilterPresets_MatchWinsOverAMissingPreset()
+        {
+            // A match means "keep" regardless, so an unresolvable id alongside it changes nothing.
+            var missing = Guid.NewGuid();
+            var matching = Guid.NewGuid();
+
+            bool failed;
+            var matched = global::ApolloSync.ApolloSync.EvaluateFilterPresets(
+                new List<Guid> { matching, missing },
+                id => id == matching ? true : (bool?)null,
+                out failed);
+
+            Assert.IsTrue(matched);
+            Assert.IsFalse(global::ApolloSync.ApolloSync.ShouldRemoveManagedGame(
+                gameExistsInLibrary: true, isPinned: false, meetsFilters: matched, filterEvaluationFailed: failed));
+        }
+
+        [TestMethod]
+        public void EvaluateFilterPresets_EveryPresetIsConsultedUntilOneMatches()
+        {
+            var consulted = new List<Guid>();
+            var a = Guid.NewGuid();
+            var b = Guid.NewGuid();
+            var c = Guid.NewGuid();
+
+            bool failed;
+            var matched = global::ApolloSync.ApolloSync.EvaluateFilterPresets(
+                new List<Guid> { a, b, c },
+                id => { consulted.Add(id); return id == b; },
+                out failed);
+
+            Assert.IsTrue(matched);
+            CollectionAssert.AreEqual(new[] { a, b }, consulted,
+                "Evaluation must short-circuit on the first match");
+        }
+
+        // ── ApplyRemovals ─────────────────────────────────────────────────────────
+
+        [TestMethod]
+        public void ApplyRemovals_RemovesTheMatchingAppEntry()
+        {
+            var sync = new SyncService();
+            var store = new ManagedStore();
+            var config = new JObject { ["apps"] = new JArray() };
+            var game = new Game("Filtered Out") { Id = Guid.NewGuid(), InstallDirectory = "C:\\F" };
+            Assert.IsTrue(sync.AddOrUpdate(config, store, game));
+
+            var disowned = global::ApolloSync.ApolloSync.ApplyRemovals(config, store.GameToUuid.ToList());
+
+            Assert.AreEqual(0, ((JArray)config["apps"]).Count);
+            CollectionAssert.AreEqual(new[] { game.Id }, disowned);
+        }
+
+        [TestMethod]
+        public void ApplyRemovals_LeavesEntriesThisExtensionDoesNotOwnAlone()
+        {
+            // The plugin's core promise: it only ever touches the entries it created.
+            var sync = new SyncService();
+            var store = new ManagedStore();
+            var config = new JObject
+            {
+                ["apps"] = new JArray
+                {
+                    new JObject { ["name"] = "Desktop", ["uuid"] = Guid.NewGuid().ToString().ToUpperInvariant() },
+                    new JObject { ["name"] = "Steam Big Picture" } // no uuid at all
+                }
+            };
+
+            var game = new Game("Managed") { Id = Guid.NewGuid(), InstallDirectory = "C:\\M" };
+            Assert.IsTrue(sync.AddOrUpdate(config, store, game));
+
+            global::ApolloSync.ApolloSync.ApplyRemovals(config, store.GameToUuid.ToList());
+
+            var apps = (JArray)config["apps"];
+            Assert.AreEqual(2, apps.Count);
+            CollectionAssert.AreEquivalent(
+                new[] { "Desktop", "Steam Big Picture" },
+                apps.Select(a => (string)((JObject)a)["name"]).ToList());
+        }
+
+        [TestMethod]
+        public void ApplyRemovals_ReportsAnOrphanWithNoAppEntry()
+        {
+            // A managed game whose entry is already gone must still be reported, or the caller
+            // sees "nothing changed", skips the save, and the store stays diverged for the
+            // session.
+            var config = new JObject { ["apps"] = new JArray() };
+            var orphan = new KeyValuePair<Guid, Guid>(Guid.NewGuid(), Guid.NewGuid());
+
+            var disowned = global::ApolloSync.ApolloSync.ApplyRemovals(config, new[] { orphan });
+
+            CollectionAssert.AreEqual(new[] { orphan.Key }, disowned);
+        }
+
+        [TestMethod]
+        public void ApplyRemovals_MatchesUppercaseUuidsAsWrittenToDisk()
+        {
+            // ConfigService upper-cases every uuid on load and save, so that is the form the
+            // matching actually has to cope with.
+            var gameId = Guid.NewGuid();
+            var uuid = Guid.NewGuid();
+            var config = new JObject
+            {
+                ["apps"] = new JArray
+                {
+                    new JObject { ["name"] = "Managed", ["uuid"] = uuid.ToString().ToUpperInvariant() }
+                }
+            };
+
+            var disowned = global::ApolloSync.ApolloSync.ApplyRemovals(
+                config, new[] { new KeyValuePair<Guid, Guid>(gameId, uuid) });
+
+            Assert.AreEqual(0, ((JArray)config["apps"]).Count);
+            CollectionAssert.AreEqual(new[] { gameId }, disowned);
+        }
+
+        // ── SaveThenDisown ────────────────────────────────────────────────────────
+
+        [TestMethod]
+        public void SaveThenDisown_FailedWriteLeavesTheStoreOwningTheGames()
+        {
+            // Regression: the store used to be updated during the removal pass, before the write.
+            // A failed write then left the in-memory store disowning entries still present in
+            // apps.json — invisible to the Manage Games list and to every later sync, until a
+            // restart. The exception here comes from the injected save, exactly as in production.
+            var store = new ManagedStore();
+            var game = new Game("Filtered Out") { Id = Guid.NewGuid(), InstallDirectory = "C:\\F" };
+            store.GameToUuid[game.Id] = Guid.NewGuid();
+
+            try
+            {
+                global::ApolloSync.ApolloSync.SaveThenDisown(
+                    () => { throw new UnauthorizedAccessException("apps.json is not writable"); },
+                    store,
+                    new[] { game.Id });
+                Assert.Fail("The write failure must propagate so the caller can report it");
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+
+            Assert.IsTrue(store.GameToUuid.ContainsKey(game.Id),
+                "A failed write must leave the store owning the game, matching the unchanged apps.json");
+        }
+
+        [TestMethod]
+        public void SaveThenDisown_SuccessfulWriteDisownsExactlyTheReportedGames()
+        {
+            var store = new ManagedStore();
+            var disowned = Guid.NewGuid();
+            var kept = Guid.NewGuid();
+            store.GameToUuid[disowned] = Guid.NewGuid();
+            store.GameToUuid[kept] = Guid.NewGuid();
+
+            var saved = false;
+            global::ApolloSync.ApolloSync.SaveThenDisown(() => saved = true, store, new[] { disowned });
+
+            Assert.IsTrue(saved);
+            Assert.IsFalse(store.GameToUuid.ContainsKey(disowned));
+            Assert.IsTrue(store.GameToUuid.ContainsKey(kept), "Only the reported games may be disowned");
+        }
+
+        // ── ExcludeReAddedGames ───────────────────────────────────────────────────
+
+        [TestMethod]
+        public void ExcludeReAddedGames_KeepsAGameTheAddPhaseRestored()
+        {
+            // Phase 1 re-evaluates the library while the add/update set was snapshotted earlier,
+            // so the two can disagree. Disowning a game whose entry Phase 2 just rewrote strands
+            // that entry in apps.json permanently — SyncManagedStore only prunes the other way.
+            var reAdded = Guid.NewGuid();
+            var genuinelyRemoved = Guid.NewGuid();
+
+            var result = global::ApolloSync.ApolloSync.ExcludeReAddedGames(
+                new[] { reAdded, genuinelyRemoved },
+                new HashSet<Guid> { reAdded });
+
+            CollectionAssert.AreEqual(new[] { genuinelyRemoved }, result);
+        }
+
+        [TestMethod]
+        public void ExcludeReAddedGames_KeepsEveryRemovalWhenNothingWasReAdded()
+        {
+            var a = Guid.NewGuid();
+            var b = Guid.NewGuid();
+
+            var result = global::ApolloSync.ApolloSync.ExcludeReAddedGames(
+                new[] { a, b }, new HashSet<Guid>());
+
+            CollectionAssert.AreEqual(new[] { a, b }, result);
         }
 
         // ── Removal wiring ────────────────────────────────────────────────────────
@@ -269,87 +489,6 @@ namespace ApolloSync.Tests
             Assert.AreEqual("Match", (string)((JObject)apps[0])["name"]);
             Assert.IsTrue(store.GameToUuid.ContainsKey(match.Id));
             Assert.IsFalse(store.GameToUuid.ContainsKey(noMatch.Id));
-        }
-
-        [TestMethod]
-        public void FilteredOutRemoval_DoesNotDisownGamesWhenTheSaveFails()
-        {
-            // Regression: RemoveFilteredOutGames used to drop the store entries itself, before
-            // SyncFilteredGamesBackground wrote apps.json. A failed write correctly skipped
-            // SaveManagedStore, so the on-disk store stayed consistent — but the in-memory one
-            // had already forgotten the games, stranding their apps.json entries with nothing
-            // tracking them: invisible to the Manage Games list and to every later sync until
-            // Playnite restarted.
-            //
-            // Mirrors the production ordering: mutate the config, and disown the games only
-            // after the write succeeds.
-            var sync = new SyncService();
-            var store = new ManagedStore();
-            var config = new JObject { ["apps"] = new JArray() };
-
-            var game = new Game("Filtered Out") { Id = Guid.NewGuid(), InstallDirectory = "C:\\F" };
-            Assert.IsTrue(sync.AddOrUpdate(config, store, game));
-
-            // Phase 1 removes the app entry and reports the id, leaving the store alone.
-            var gamesToUnmanage = new List<Guid> { game.Id };
-            var apps = (JArray)config["apps"];
-            apps.RemoveAt(0);
-
-            Assert.IsTrue(store.GameToUuid.ContainsKey(game.Id),
-                "The store must still own the game until the write lands");
-
-            // The write fails.
-            var saveSucceeded = false;
-            try
-            {
-                throw new UnauthorizedAccessException("apps.json is not writable");
-            }
-            catch (UnauthorizedAccessException)
-            {
-                saveSucceeded = false;
-            }
-
-            if (saveSucceeded)
-            {
-                foreach (var id in gamesToUnmanage) { Guid removed; store.GameToUuid.TryRemove(id, out removed); }
-            }
-
-            Assert.IsTrue(store.GameToUuid.ContainsKey(game.Id),
-                "A failed write must leave the store owning the game, matching the unchanged apps.json");
-
-            // And once a write does succeed, ownership is correctly released.
-            foreach (var id in gamesToUnmanage) { Guid removed; store.GameToUuid.TryRemove(id, out removed); }
-            Assert.IsFalse(store.GameToUuid.ContainsKey(game.Id));
-        }
-
-        [TestMethod]
-        public void FilteredOutRemoval_ReportsOrphanedStoreEntriesToo()
-        {
-            // The count returned by RemoveFilteredOutGames drives the "did anything change?"
-            // guard around the save. It used to count app objects actually deleted from
-            // apps.json, so a managed game whose entry was already missing shed its store entry
-            // while reporting zero — and the save block never ran, leaving the in-memory store
-            // diverged from the persisted one for the rest of the session.
-            var store = new ManagedStore();
-            var orphan = Guid.NewGuid();
-            store.GameToUuid[orphan] = Guid.NewGuid();
-
-            var config = new JObject { ["apps"] = new JArray() };
-            var apps = (JArray)config["apps"];
-
-            // Production shape: the id is reported whether or not a matching app entry existed.
-            var gamesToUnmanage = new List<Guid>();
-            var appToRemove = apps.OfType<JObject>().FirstOrDefault(a =>
-                Guid.TryParse((string)a["uuid"], out var uuid) && uuid == store.GameToUuid[orphan]);
-            if (appToRemove != null)
-            {
-                apps.Remove(appToRemove);
-            }
-            gamesToUnmanage.Add(orphan);
-
-            Assert.AreEqual(0, apps.Count);
-            Assert.AreEqual(1, gamesToUnmanage.Count,
-                "An orphaned store entry must still be reported, or the save that persists its removal is skipped");
         }
 
         // ── ManuallyRemoved round-trip ────────────────────────────────────────────

--- a/Tests/AppsJsonManagementTests.cs
+++ b/Tests/AppsJsonManagementTests.cs
@@ -166,6 +166,72 @@ namespace ApolloSync.Tests
                 gameExistsInLibrary: true, isPinned: false, meetsFilters: false, filterEvaluationFailed: true));
         }
 
+        // ── FilterPresetsAreEvaluable ─────────────────────────────────────────────
+        // Guards the case that made removal-on-every-sync dangerous: a selected preset id
+        // that no longer resolves reads as "matched nothing" unless it is caught here.
+
+        [TestMethod]
+        public void FilterPresetsAreEvaluable_NoPresetsSelectedIsDeliberate()
+        {
+            // Selecting nothing means "export nothing", so pruning must still be allowed.
+            Assert.IsTrue(global::ApolloSync.ApolloSync.FilterPresetsAreEvaluable(
+                selectedPresetCount: 0, resolvedPresetCount: 0));
+        }
+
+        [TestMethod]
+        public void FilterPresetsAreEvaluable_AllSelectedPresetsResolve()
+        {
+            Assert.IsTrue(global::ApolloSync.ApolloSync.FilterPresetsAreEvaluable(
+                selectedPresetCount: 3, resolvedPresetCount: 3));
+        }
+
+        [TestMethod]
+        public void FilterPresetsAreEvaluable_OneSelectedPresetWentMissing()
+        {
+            Assert.IsFalse(global::ApolloSync.ApolloSync.FilterPresetsAreEvaluable(
+                selectedPresetCount: 3, resolvedPresetCount: 2));
+        }
+
+        [TestMethod]
+        public void FilterPresetsAreEvaluable_EverySelectedPresetWentMissing()
+        {
+            Assert.IsFalse(global::ApolloSync.ApolloSync.FilterPresetsAreEvaluable(
+                selectedPresetCount: 2, resolvedPresetCount: 0));
+        }
+
+        [TestMethod]
+        public void DeletedFilterPreset_DoesNotRemoveManagedGames()
+        {
+            // Regression: deleting a preset in Playnite (or deleting and recreating it, which
+            // assigns a new id) leaves a stale id in IncludedFilterPresetIds. That used to
+            // resolve to nothing, evaluate as "no match", and — now that removal runs on every
+            // sync rather than only when something matched — delete every non-pinned entry.
+            var evaluable = global::ApolloSync.ApolloSync.FilterPresetsAreEvaluable(
+                selectedPresetCount: 1, resolvedPresetCount: 0);
+
+            Assert.IsFalse(evaluable);
+            Assert.IsFalse(global::ApolloSync.ApolloSync.ShouldRemoveManagedGame(
+                gameExistsInLibrary: true,
+                isPinned: false,
+                meetsFilters: false,
+                filterEvaluationFailed: !evaluable));
+        }
+
+        [TestMethod]
+        public void ClearingEveryFilterPreset_StillRemovesManagedGames()
+        {
+            // The behaviour this change exists to deliver: unchecking everything prunes.
+            var evaluable = global::ApolloSync.ApolloSync.FilterPresetsAreEvaluable(
+                selectedPresetCount: 0, resolvedPresetCount: 0);
+
+            Assert.IsTrue(evaluable);
+            Assert.IsTrue(global::ApolloSync.ApolloSync.ShouldRemoveManagedGame(
+                gameExistsInLibrary: true,
+                isPinned: false,
+                meetsFilters: false,
+                filterEvaluationFailed: !evaluable));
+        }
+
         // ── Removal wiring ────────────────────────────────────────────────────────
 
         [TestMethod]

--- a/Tests/AppsJsonManagementTests.cs
+++ b/Tests/AppsJsonManagementTests.cs
@@ -271,6 +271,87 @@ namespace ApolloSync.Tests
             Assert.IsFalse(store.GameToUuid.ContainsKey(noMatch.Id));
         }
 
+        [TestMethod]
+        public void FilteredOutRemoval_DoesNotDisownGamesWhenTheSaveFails()
+        {
+            // Regression: RemoveFilteredOutGames used to drop the store entries itself, before
+            // SyncFilteredGamesBackground wrote apps.json. A failed write correctly skipped
+            // SaveManagedStore, so the on-disk store stayed consistent — but the in-memory one
+            // had already forgotten the games, stranding their apps.json entries with nothing
+            // tracking them: invisible to the Manage Games list and to every later sync until
+            // Playnite restarted.
+            //
+            // Mirrors the production ordering: mutate the config, and disown the games only
+            // after the write succeeds.
+            var sync = new SyncService();
+            var store = new ManagedStore();
+            var config = new JObject { ["apps"] = new JArray() };
+
+            var game = new Game("Filtered Out") { Id = Guid.NewGuid(), InstallDirectory = "C:\\F" };
+            Assert.IsTrue(sync.AddOrUpdate(config, store, game));
+
+            // Phase 1 removes the app entry and reports the id, leaving the store alone.
+            var gamesToUnmanage = new List<Guid> { game.Id };
+            var apps = (JArray)config["apps"];
+            apps.RemoveAt(0);
+
+            Assert.IsTrue(store.GameToUuid.ContainsKey(game.Id),
+                "The store must still own the game until the write lands");
+
+            // The write fails.
+            var saveSucceeded = false;
+            try
+            {
+                throw new UnauthorizedAccessException("apps.json is not writable");
+            }
+            catch (UnauthorizedAccessException)
+            {
+                saveSucceeded = false;
+            }
+
+            if (saveSucceeded)
+            {
+                foreach (var id in gamesToUnmanage) { Guid removed; store.GameToUuid.TryRemove(id, out removed); }
+            }
+
+            Assert.IsTrue(store.GameToUuid.ContainsKey(game.Id),
+                "A failed write must leave the store owning the game, matching the unchanged apps.json");
+
+            // And once a write does succeed, ownership is correctly released.
+            foreach (var id in gamesToUnmanage) { Guid removed; store.GameToUuid.TryRemove(id, out removed); }
+            Assert.IsFalse(store.GameToUuid.ContainsKey(game.Id));
+        }
+
+        [TestMethod]
+        public void FilteredOutRemoval_ReportsOrphanedStoreEntriesToo()
+        {
+            // The count returned by RemoveFilteredOutGames drives the "did anything change?"
+            // guard around the save. It used to count app objects actually deleted from
+            // apps.json, so a managed game whose entry was already missing shed its store entry
+            // while reporting zero — and the save block never ran, leaving the in-memory store
+            // diverged from the persisted one for the rest of the session.
+            var store = new ManagedStore();
+            var orphan = Guid.NewGuid();
+            store.GameToUuid[orphan] = Guid.NewGuid();
+
+            var config = new JObject { ["apps"] = new JArray() };
+            var apps = (JArray)config["apps"];
+
+            // Production shape: the id is reported whether or not a matching app entry existed.
+            var gamesToUnmanage = new List<Guid>();
+            var appToRemove = apps.OfType<JObject>().FirstOrDefault(a =>
+                Guid.TryParse((string)a["uuid"], out var uuid) && uuid == store.GameToUuid[orphan]);
+            if (appToRemove != null)
+            {
+                apps.Remove(appToRemove);
+            }
+            gamesToUnmanage.Add(orphan);
+
+            Assert.AreEqual(0, apps.Count);
+            Assert.AreEqual(1, gamesToUnmanage.Count,
+                "An orphaned store entry must still be reported, or the save that persists its removal is skipped");
+        }
+
         // ── ManuallyRemoved round-trip ────────────────────────────────────────────
 
         [TestMethod]

--- a/extension.yaml
+++ b/extension.yaml
@@ -1,7 +1,7 @@
 Id: ApolloSync_f987343d-4168-4f44-9fb0-e3a21da314ad
 Name: ApolloSync
 Author: sharkusmanch
-Version: 1.3.0
+Version: 1.3.1
 Module: ApolloSync.dll
 Type: GenericPlugin
 Icon: icon.png

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,5 +1,16 @@
 AddonId: ApolloSync_f987343d-4168-4f44-9fb0-e3a21da314ad
 Packages:
+  - Version: 1.3.1
+    RequiredApiVersion: 6.16.0
+    ReleaseDate: 2026-07-28
+    PackageUrl: https://github.com/sharkusmanch/playnite-apollo-sync/releases/download/v1.3.1/ApolloSync_v1.3.1.pext
+    Changelog:
+      - Unchecking a filter preset now removes its games from apps.json on the next sync, instead of leaving them until something else happened to match
+      - Deleting a filter preset in Playnite no longer causes every unpinned game to be removed
+      - A failed apps.json write no longer leaves the plugin tracking games it did not export, which made them vanish from the managed games list until a restart
+      - Games removed and re-added within the same sync are no longer left orphaned in apps.json
+      - Editing filter presets while a sync is running no longer risks removing the games you were about to re-select
+      - A filter that matches nothing now shows one notification instead of two contradictory ones
   - Version: 1.3.0
     RequiredApiVersion: 6.16.0
     ReleaseDate: 2026-07-26


### PR DESCRIPTION
Extracted from #26 by @kinland, rebased onto current `master`. The first commit is authored to them.

## 1. The bug (@kinland)

`SyncFilteredGamesBackground` returned early whenever `GetFilteredGames()` came back empty:

```csharp
var filteredGames = GetFilteredGames();
if (filteredGames.Count == 0) { ...notify...; return; }   // <- before Phase 1
```

Phase 1 (`RemoveFilteredOutGames`) sits *after* that return, so unchecking a filter preset — or clearing all of them — never pruned anything. The games stayed in `apps.json` until some later sync happened to match at least one game and drag execution past the early return. @kinland hit this while working on #26 and fixed it there.

Removal now always runs before add/update.

## 2. The hole that opening this up exposed

`GameMeetsCurrentFilters` flagged `evaluationFailed` only when `GetGameMatchesFilter` **threw**. A selected preset id that no longer *resolves* was skipped silently — so it read as "did not match". Deleting a preset in Playnite, or deleting and recreating it (recreating assigns a new id), leaves the stale id in `IncludedFilterPresetIds`, and nothing prunes it. With the early return gone, the next automatic sync — startup, library update, or settings save, all on by default — would evaluate every managed game as non-matching and delete the lot. The early return was the only thing making that harmless.

An id that no longer resolves is now "could not determine", so no removal decision is made. Selecting nothing at all stays a deliberate export-nothing and still prunes.

## 3. Two pre-existing store-consistency bugs in the same method

`RemoveFilteredOutGames` dropped entries from the in-memory managed store before the caller wrote `apps.json`. A failed write correctly skipped `SaveManagedStore`, so the on-disk store stayed consistent — but the in-memory one had already forgotten those games, stranding their `apps.json` entries with nothing tracking them until a restart. The default Program Files install takes the non-atomic fallback write and can prompt for elevation, so a declined prompt is a realistic way in.

It now returns the ids to disown, applied after `SaveAppsConfig` returns — the ordering `ExportGamesWithFeedback` already uses. That also closes a second divergence: the old count incremented only for app objects actually deleted while store entries were dropped unconditionally, so an already-missing entry reported zero, skipped the save block, and left the store diverged for the session.

## 4. Testability, and what it surfaced

Mutation testing found that **every** production change on this branch survived the suite — the early return could be restored, the disown loop deleted, or the evaluability check removed, and all 55 tests still passed. Two of the tests added in commit 3 were tautologies that invoked no production code at all.

Four seams were extracted, in the shape the repo already uses for `ShouldRemoveManagedGame` — small pure internal statics, no interfaces, no mocking framework:

| Seam | Covers |
|---|---|
| `EvaluateFilterPresets` | the OR-across-presets rule, Playnite lookup behind a delegate (null = unresolved, throw = failed) |
| `ApplyRemovals` | the `apps.json` surgery, keyed strictly on the store's recorded UUID |
| `SaveThenDisown` | write-then-disown ordering, tested with a save that actually throws |
| `ExcludeReAddedGames` | see below |

`FilterPresetsAreEvaluable` is gone: its only call site sat inside `if (selectedPresetIds?.Count > 0)`, so the `(0, 0)` case two of its tests asserted on was unreachable. All four previously-surviving mutants are now killed. One of the new tests covers something nothing verified before — that removal leaves entries this extension does not own alone, which is the plugin's core promise.

### Fixed while extracting

- **Phase 2 re-adding a game Phase 1 removed** left an `apps.json` entry with no store entry, once disowning moved after the write. The phases evaluate at different times against a live library and can disagree — a game deleted mid-sync, say. `SyncManagedStore` only prunes the opposite direction, so a restart could not recover it. Introduced by commit 3; caught by review before merge.
- **Selected preset ids are now snapshotted once per sync.** The settings view edits that list in place on the UI thread as boxes are ticked — before OK, and undone only in memory by Cancel — so a concurrent sync could enumerate it mid-mutation, or observe a transient empty list and prune everything the user was about to re-select.
- A misconfigured filter produced **two** notifications, an error plus a contradictory "0 succeeded, 0 failed". It returns after the error again.
- The unresolvable-preset warning moved out of the per-game path, where one deleted preset produced a warn line per managed game per sync.
- The cancellation comment claimed more than the check delivers; it now describes only the window it actually covers.

## Behavior changes

- Unchecking every preset now prunes all extension-managed, non-pinned entries on the next sync. That is the intended meaning of "nothing is selected", but it is a change from today, so it is called out in the README. Pinned games and entries this extension did not create are untouched.
- "Removed N filtered out games" now counts games disowned rather than app objects deleted, so it includes entries that were already missing from `apps.json`.

## What was left out of #26

#26 also adds sync-by-tags, a preset/tag search box, and OR/AND/NOT combination modes across 20 locale files. Most of that is redundant with what presets already do: `FilterPresetSettings` exposes `Tag` (an `IdItemFilterItemProperties`) plus `UseAndFilteringStyle`, so "any of these tags", "all of these tags", and "preset AND tag" are all already expressible as a Playnite filter preset, which this plugin already consumes. The README now mentions tags explicitly so that is discoverable.

The exception is #26's **NOT** mode, which is *not* redundant — the SDK filter model has no negation on any dimension, so "export this preset except anything tagged *Broken*" genuinely cannot be built as a preset. That gap is tracked in #30, along with the shape it should probably take. It is out of scope here, but it is not dismissed.

## Verification

- `dotnet build ApolloSync.csproj -c Release` — succeeds
- `dotnet test Tests/ApolloSync.Tests.csproj` — 63/63 pass (16 new)
- Mutation-checked: reverting the evaluability flag, the disown ordering, the orphan reporting, or the re-add guard each fails the suite

Still not covered: the phase ordering inside `SyncFilteredGamesBackground` itself and the cancellation check, both of which need a live `IPlayniteAPI`. Covering those would mean extracting the whole orchestrator behind six delegates, which is more indirection than the risk warrants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)