### PR TITLE
Fix cover art in Moonlight: real format detection and 3:4 normalisation

### DIFF
--- a/ApolloSync.cs
+++ b/ApolloSync.cs
@@ -34,7 +34,9 @@ namespace ApolloSync
         public ApolloSync(IPlayniteAPI api) : base(api)
         {
             _settings = new ApolloSyncSettingsViewModel(this);
-            syncService = new SyncService(api);
+            // Read through a delegate rather than a snapshot: the user can toggle this while the
+            // plugin is loaded, and the next sync must honour the current value.
+            syncService = new SyncService(api, manageCoverImages: () => _settings.Settings.ManageCoverImages);
             Properties = new GenericPluginProperties
             {
                 HasSettings = true
@@ -208,6 +210,10 @@ namespace ApolloSync
         {
             // Skip if a full sync is already running
             if (_syncRunning == 1) return;
+
+            // This handler exists purely to react to cover art changes. With cover management
+            // off there is nothing to re-export, and rewriting apps.json would be pure churn.
+            if (!_settings.Settings.ManageCoverImages) return;
 
             foreach (var update in args.UpdatedItems)
             {

--- a/Localization/cs_CZ.xaml
+++ b/Localization/cs_CZ.xaml
@@ -44,6 +44,9 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames_Help">Pokud je povoleno, budou pro export zvažovány pouze nainstalované hry.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_NoLabel">Štítek není vyžadován</sys:String>
     <sys:String x:Key="LOC_ApolloSync_DefaultLabel_Name">Apollo/Sunshine</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_CoverImages">Obrázky obalů:</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ManageCoverImages">Exportovat obrázky obalů</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ManageCoverImages_Help">Exportuje obal každé hry z Playnite jako obrázek obalu, převedený do formátu PNG a přizpůsobený poměru 3:4, který Moonlight očekává. Vypnutím této volby zachováte obrázky, které jste si sami nastavili v Apollo/Sunshine – stávající obaly pak zůstanou nezměněny.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Předvolba filtru</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Použít předvolbu filtru Playnite</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Pokud je povoleno, bude místo jednotlivých filtrů níže použita vybraná předvolba filtru. Předvolby filtrů vytvořte v hlavním zobrazení knihovny Playnite.</sys:String>

--- a/Localization/de_DE.xaml
+++ b/Localization/de_DE.xaml
@@ -44,6 +44,9 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames_Help">Wenn aktiviert, werden nur installierte Spiele für den Export berücksichtigt.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_NoLabel">Kein Label erforderlich</sys:String>
     <sys:String x:Key="LOC_ApolloSync_DefaultLabel_Name">Apollo/Sunshine</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_CoverImages">Cover-Bilder:</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ManageCoverImages">Cover-Bilder exportieren</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ManageCoverImages_Help">Exportiert das Playnite-Cover jedes Spiels als Box-Art, konvertiert es nach PNG und passt es an das von Moonlight erwartete 3:4-Format an. Deaktivieren Sie diese Option, um Bilder zu behalten, die Sie selbst in Apollo/Sunshine festgelegt haben – vorhandene Box-Art bleibt dann unverändert.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Filtervoreinstellung</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Playnite-Filtervoreinstellung verwenden</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Wenn aktiviert, wird die ausgewählte Filtervoreinstellung anstelle der einzelnen Filter unten verwendet. Erstellen Sie Filtervoreinstellungen in der Hauptbibliotheksansicht von Playnite.</sys:String>

--- a/Localization/en_US.xaml
+++ b/Localization/en_US.xaml
@@ -44,6 +44,9 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames_Help">When enabled, only installed games will be considered for export.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_NoLabel">No label required</sys:String>
     <sys:String x:Key="LOC_ApolloSync_DefaultLabel_Name">Apollo/Sunshine</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_CoverImages">Cover images:</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ManageCoverImages">Export cover images</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ManageCoverImages_Help">Exports each game's Playnite cover as box art, converted to PNG and fitted to the 3:4 frame Moonlight expects. Turn this off to keep artwork you have set yourself in Apollo/Sunshine — existing box art is then left untouched.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Filter Preset</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Use Playnite Filter Preset</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">When enabled, the selected filter preset will be used instead of the individual filters below. Create filter presets in Playnite's main library view.</sys:String>

--- a/Localization/es_ES.xaml
+++ b/Localization/es_ES.xaml
@@ -44,6 +44,9 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames_Help">Cuando está activado, solo se considerarán para exportar los juegos instalados.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_NoLabel">Sin etiqueta requerida</sys:String>
     <sys:String x:Key="LOC_ApolloSync_DefaultLabel_Name">Apollo/Sunshine</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_CoverImages">Imágenes de portada:</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ManageCoverImages">Exportar imágenes de portada</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ManageCoverImages_Help">Exporta la portada de Playnite de cada juego como carátula, convertida a PNG y ajustada al marco 3:4 que espera Moonlight. Desactiva esta opción para conservar las imágenes que hayas configurado tú mismo en Apollo/Sunshine — las carátulas existentes no se modificarán.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Preajuste de filtro</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Usar preajuste de filtro de Playnite</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Cuando está activado, se usará el preajuste de filtro seleccionado en lugar de los filtros individuales de abajo. Crea preajustes de filtro en la vista principal de la biblioteca de Playnite.</sys:String>

--- a/Localization/fr_FR.xaml
+++ b/Localization/fr_FR.xaml
@@ -44,6 +44,9 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames_Help">Lorsque activé, seuls les jeux installés seront pris en compte pour l'exportation.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_NoLabel">Aucune étiquette requise</sys:String>
     <sys:String x:Key="LOC_ApolloSync_DefaultLabel_Name">Apollo/Sunshine</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_CoverImages">Images de couverture :</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ManageCoverImages">Exporter les images de couverture</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ManageCoverImages_Help">Exporte la couverture Playnite de chaque jeu en tant que jaquette, convertie en PNG et ajustée au format 3:4 attendu par Moonlight. Désactivez cette option pour conserver les illustrations que vous avez définies vous-même dans Apollo/Sunshine — les jaquettes existantes restent alors inchangées.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Préréglage de filtre</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Utiliser un préréglage de filtre Playnite</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Lorsque activé, le préréglage de filtre sélectionné sera utilisé à la place des filtres individuels ci-dessous. Créez des préréglages de filtre dans la vue principale de la bibliothèque Playnite.</sys:String>

--- a/Localization/it_IT.xaml
+++ b/Localization/it_IT.xaml
@@ -44,6 +44,9 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames_Help">Quando attivato, solo i giochi installati verranno considerati per l'esportazione.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_NoLabel">Nessuna etichetta richiesta</sys:String>
     <sys:String x:Key="LOC_ApolloSync_DefaultLabel_Name">Apollo/Sunshine</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_CoverImages">Immagini di copertina:</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ManageCoverImages">Esporta le immagini di copertina</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ManageCoverImages_Help">Esporta la copertina Playnite di ogni gioco come box art, convertita in PNG e adattata al formato 3:4 richiesto da Moonlight. Disattiva questa opzione per mantenere le immagini che hai impostato tu stesso in Apollo/Sunshine — le box art esistenti non verranno modificate.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Preset filtro</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Usa preset filtro di Playnite</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Quando attivato, verrà utilizzato il preset filtro selezionato al posto dei filtri individuali sottostanti. Crea i preset filtro nella vista principale della libreria di Playnite.</sys:String>

--- a/Localization/ja_JP.xaml
+++ b/Localization/ja_JP.xaml
@@ -44,6 +44,9 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames_Help">有効にすると、インストール済みのゲームのみがエクスポート対象になります。</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_NoLabel">ラベル指定なし</sys:String>
     <sys:String x:Key="LOC_ApolloSync_DefaultLabel_Name">Apollo/Sunshine</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_CoverImages">カバー画像:</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ManageCoverImages">カバー画像をエクスポート</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ManageCoverImages_Help">各ゲームのPlayniteのカバー画像を、PNGに変換したうえでMoonlightが想定する3:4の枠に合わせ、ボックスアートとしてエクスポートします。オフにすると、Apollo/Sunshineでご自身が設定したアートワークが保持され、既存のボックスアートは変更されません。</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">フィルタープリセット</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Playniteのフィルタープリセットを使用</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">有効にすると、以下の個別フィルターの代わりに選択したフィルタープリセットが使用されます。フィルタープリセットはPlayniteのメインライブラリ画面で作成できます。</sys:String>

--- a/Localization/ko_KR.xaml
+++ b/Localization/ko_KR.xaml
@@ -44,6 +44,9 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames_Help">활성화하면 설치된 게임만 내보내기 대상이 됩니다.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_NoLabel">라벨 필요 없음</sys:String>
     <sys:String x:Key="LOC_ApolloSync_DefaultLabel_Name">Apollo/Sunshine</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_CoverImages">커버 이미지:</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ManageCoverImages">커버 이미지 내보내기</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ManageCoverImages_Help">각 게임의 Playnite 커버를 PNG로 변환하고 Moonlight가 사용하는 3:4 비율에 맞춰 박스 아트로 내보냅니다. 이 옵션을 끄면 Apollo/Sunshine에서 직접 설정한 아트워크가 유지되며, 기존 박스 아트는 변경되지 않습니다.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">필터 프리셋</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Playnite 필터 프리셋 사용</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">활성화하면 아래의 개별 필터 대신 선택한 필터 프리셋이 사용됩니다. 필터 프리셋은 Playnite의 메인 라이브러리 화면에서 만들 수 있습니다.</sys:String>

--- a/Localization/nl_NL.xaml
+++ b/Localization/nl_NL.xaml
@@ -44,6 +44,9 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames_Help">Wanneer ingeschakeld, worden alleen geïnstalleerde games in aanmerking genomen voor export.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_NoLabel">Geen label vereist</sys:String>
     <sys:String x:Key="LOC_ApolloSync_DefaultLabel_Name">Apollo/Sunshine</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_CoverImages">Coverafbeeldingen:</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ManageCoverImages">Coverafbeeldingen exporteren</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ManageCoverImages_Help">Exporteert de Playnite-cover van elke game als box art, geconverteerd naar PNG en passend gemaakt voor het 3:4-kader dat Moonlight verwacht. Schakel dit uit om afbeeldingen te behouden die u zelf in Apollo/Sunshine hebt ingesteld – bestaande box art blijft dan ongewijzigd.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Filtervoorinstelling</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Playnite-filtervoorinstelling gebruiken</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Wanneer ingeschakeld, wordt de geselecteerde filtervoorinstelling gebruikt in plaats van de afzonderlijke filters hieronder. Maak filtervoorinstellingen aan in de hoofdbibliotheekweergave van Playnite.</sys:String>

--- a/Localization/pl_PL.xaml
+++ b/Localization/pl_PL.xaml
@@ -44,6 +44,9 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames_Help">Po włączeniu tylko zainstalowane gry będą brane pod uwagę przy eksporcie.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_NoLabel">Etykieta nie jest wymagana</sys:String>
     <sys:String x:Key="LOC_ApolloSync_DefaultLabel_Name">Apollo/Sunshine</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_CoverImages">Okładki:</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ManageCoverImages">Eksportuj okładki</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ManageCoverImages_Help">Eksportuje okładkę każdej gry z Playnite jako grafikę pudełkową, konwertuje ją do formatu PNG i dopasowuje do proporcji 3:4 oczekiwanych przez Moonlight. Wyłącz tę opcję, aby zachować grafikę ustawioną samodzielnie w Apollo/Sunshine – istniejąca grafika pudełkowa pozostanie wtedy nienaruszona.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Szablon filtrów</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Użyj szablonu filtrów Playnite</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Po włączeniu wybrany szablon filtrów zostanie użyty zamiast poszczególnych filtrów poniżej. Twórz szablony filtrów w głównym widoku biblioteki Playnite.</sys:String>

--- a/Localization/pt_BR.xaml
+++ b/Localization/pt_BR.xaml
@@ -44,6 +44,9 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames_Help">Quando ativado, apenas jogos instalados serão considerados para exportação.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_NoLabel">Nenhuma etiqueta necessária</sys:String>
     <sys:String x:Key="LOC_ApolloSync_DefaultLabel_Name">Apollo/Sunshine</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_CoverImages">Imagens de capa:</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ManageCoverImages">Exportar imagens de capa</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ManageCoverImages_Help">Exporta a capa do Playnite de cada jogo como arte de capa, convertida para PNG e ajustada ao formato 3:4 que o Moonlight espera. Desative esta opção para manter as imagens que você mesmo definiu no Apollo/Sunshine — as artes de capa existentes não serão alteradas.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Predefinição de filtro</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Usar predefinição de filtro do Playnite</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Quando ativado, a predefinição de filtro selecionada será usada no lugar dos filtros individuais abaixo. Crie predefinições de filtro na visualização principal da biblioteca do Playnite.</sys:String>

--- a/Localization/pt_PT.xaml
+++ b/Localization/pt_PT.xaml
@@ -44,6 +44,9 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames_Help">Quando ativado, apenas os jogos instalados serão considerados para exportação.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_NoLabel">Nenhuma etiqueta necessária</sys:String>
     <sys:String x:Key="LOC_ApolloSync_DefaultLabel_Name">Apollo/Sunshine</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_CoverImages">Imagens de capa:</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ManageCoverImages">Exportar imagens de capa</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ManageCoverImages_Help">Exporta a capa do Playnite de cada jogo como arte de capa, convertida para PNG e ajustada ao formato 3:4 esperado pelo Moonlight. Desative esta opção para preservar as imagens que tenha definido no Apollo/Sunshine — as artes de capa existentes ficam inalteradas.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Predefinição de filtro</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Usar predefinição de filtro do Playnite</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Quando ativado, a predefinição de filtro selecionada será utilizada em vez dos filtros individuais abaixo. Crie predefinições de filtro na vista principal da biblioteca do Playnite.</sys:String>

--- a/Localization/ro_RO.xaml
+++ b/Localization/ro_RO.xaml
@@ -44,6 +44,9 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames_Help">Când este activat, doar jocurile instalate vor fi luate în considerare pentru export.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_NoLabel">Nicio etichetă necesară</sys:String>
     <sys:String x:Key="LOC_ApolloSync_DefaultLabel_Name">Apollo/Sunshine</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_CoverImages">Imagini de copertă:</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ManageCoverImages">Exportă imaginile de copertă</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ManageCoverImages_Help">Exportă coperta Playnite a fiecărui joc drept copertă de joc, convertită în PNG și încadrată în formatul 3:4 așteptat de Moonlight. Dezactivează această opțiune pentru a păstra imaginile pe care le-ai setat tu însuți în Apollo/Sunshine — copertele existente rămân neatinse.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Presetare filtru</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Folosește presetarea de filtru Playnite</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Când este activat, presetarea de filtru selectată va fi folosită în locul filtrelor individuale de mai jos. Creează presetări de filtru în vizualizarea principală a bibliotecii Playnite.</sys:String>

--- a/Localization/ru_RU.xaml
+++ b/Localization/ru_RU.xaml
@@ -44,6 +44,9 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames_Help">Если включено, только установленные игры будут рассматриваться для экспорта.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_NoLabel">Метка не требуется</sys:String>
     <sys:String x:Key="LOC_ApolloSync_DefaultLabel_Name">Apollo/Sunshine</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_CoverImages">Обложки:</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ManageCoverImages">Экспортировать обложки</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ManageCoverImages_Help">Экспортирует обложку каждой игры из Playnite, преобразуя её в PNG и подгоняя под соотношение сторон 3:4, которое ожидает Moonlight. Отключите этот параметр, чтобы сохранить изображения, заданные вами вручную в Apollo/Sunshine — существующие обложки останутся без изменений.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Предустановка фильтра</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Использовать предустановку фильтра Playnite</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Если включено, вместо отдельных фильтров ниже будет использоваться выбранная предустановка фильтра. Создавайте предустановки фильтров в главном представлении библиотеки Playnite.</sys:String>

--- a/Localization/sv_SE.xaml
+++ b/Localization/sv_SE.xaml
@@ -44,6 +44,9 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames_Help">När aktiverat kommer bara installerade spel att övervägas för export.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_NoLabel">Ingen etikett krävs</sys:String>
     <sys:String x:Key="LOC_ApolloSync_DefaultLabel_Name">Apollo/Sunshine</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_CoverImages">Omslagsbilder:</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ManageCoverImages">Exportera omslagsbilder</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ManageCoverImages_Help">Exporterar varje spels omslag från Playnite som omslagsbild, konverterat till PNG och anpassat till det 3:4-format som Moonlight förväntar sig. Stäng av detta för att behålla bilder som du själv har angett i Apollo/Sunshine – befintliga omslagsbilder lämnas då orörda.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Filterförinställning</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Använd Playnite-filterförinställning</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">När aktiverat används den valda filterförinställningen istället för de enskilda filtren nedan. Skapa filterförinställningar i Playnites huvudbiblioteksvy.</sys:String>

--- a/Localization/tr_TR.xaml
+++ b/Localization/tr_TR.xaml
@@ -44,6 +44,9 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames_Help">Etkinleştirildiğinde, yalnızca yüklü oyunlar aktarım için değerlendirilir.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_NoLabel">Etiket gerekli değil</sys:String>
     <sys:String x:Key="LOC_ApolloSync_DefaultLabel_Name">Apollo/Sunshine</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_CoverImages">Kapak görselleri:</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ManageCoverImages">Kapak görsellerini aktar</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ManageCoverImages_Help">Her oyunun Playnite kapak görselini PNG'ye dönüştürüp Moonlight'ın beklediği 3:4 çerçeveye uyarlayarak kutu görseli olarak aktarır. Apollo/Sunshine üzerinde kendi ayarladığınız görselleri korumak için bunu kapatın — mevcut kutu görselleri o zaman olduğu gibi bırakılır.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Filtre Ön Ayarı</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Playnite Filtre Ön Ayarını Kullan</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Etkinleştirildiğinde, aşağıdaki ayrı filtreler yerine seçilen filtre ön ayarı kullanılır. Filtre ön ayarlarını Playnite'ın ana kütüphane görünümünde oluşturabilirsiniz.</sys:String>

--- a/Localization/uk_UA.xaml
+++ b/Localization/uk_UA.xaml
@@ -44,6 +44,9 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames_Help">Якщо увімкнено, лише встановлені ігри будуть розглядатися для експорту.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_NoLabel">Мітка не потрібна</sys:String>
     <sys:String x:Key="LOC_ApolloSync_DefaultLabel_Name">Apollo/Sunshine</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_CoverImages">Обкладинки:</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ManageCoverImages">Експортувати обкладинки</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ManageCoverImages_Help">Експортує обкладинку кожної гри з Playnite, перетворюючи її на PNG та припасовуючи до співвідношення сторін 3:4, якого очікує Moonlight. Вимкніть цей параметр, щоб зберегти зображення, задані вами вручну в Apollo/Sunshine — наявні обкладинки залишаться без змін.</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Набір фільтрів</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Використовувати набір фільтрів Playnite</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Якщо увімкнено, замість окремих фільтрів нижче буде використовуватися вибраний набір фільтрів. Створюйте набори фільтрів у головному вигляді бібліотеки Playnite.</sys:String>

--- a/Localization/zh_CN.xaml
+++ b/Localization/zh_CN.xaml
@@ -44,6 +44,9 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames_Help">启用后，仅已安装的游戏会被纳入导出范围。</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_NoLabel">不需要标签</sys:String>
     <sys:String x:Key="LOC_ApolloSync_DefaultLabel_Name">Apollo/Sunshine</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_CoverImages">封面图片：</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ManageCoverImages">导出封面图片</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ManageCoverImages_Help">将每个游戏在Playnite中的封面导出为封面图，转换为PNG并适配Moonlight所需的3:4画框。关闭此项可保留您自己在Apollo/Sunshine中设置的图片——现有封面图将保持不变。</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">筛选预设</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">使用Playnite筛选预设</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">启用后，将使用所选的筛选预设替代下方的各项筛选条件。可在Playnite的主库视图中创建筛选预设。</sys:String>

--- a/Localization/zh_TW.xaml
+++ b/Localization/zh_TW.xaml
@@ -44,6 +44,9 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_IncludeInstalledGames_Help">啟用後，僅已安裝的遊戲會被納入匯出範圍。</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_NoLabel">不需要標籤</sys:String>
     <sys:String x:Key="LOC_ApolloSync_DefaultLabel_Name">Apollo/Sunshine</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_CoverImages">封面圖片：</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ManageCoverImages">匯出封面圖片</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ManageCoverImages_Help">將每款遊戲在Playnite中的封面匯出為封面圖，轉換為PNG並符合Moonlight所需的3:4畫框。關閉此項可保留您自行在Apollo/Sunshine中設定的圖片——現有封面圖將維持不變。</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">篩選預設</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">使用Playnite篩選預設</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">啟用後，將使用所選的篩選預設取代下方的各項篩選條件。可在Playnite的主媒體庫檢視中建立篩選預設。</sys:String>

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A Playnite extension that syncs your game library to [Apollo](https://github.com
 
 - **Automatic sync** -- exports games matching your filters to Apollo/Sunshine's `apps.json` on install, library update, settings change, or Playnite startup (each individually configurable)
 - **Filter presets** -- uses your existing Playnite filter presets to decide what gets exported (OR logic when multiple are selected). Filter by tag, platform, category, completion status or anything else by building the preset in Playnite's library view. Unchecking a preset removes its games from `apps.json` on the next sync, unless they are pinned.
+- **Cover art** -- exports each game's Playnite cover as box art, re-encoded to PNG and fitted to the 3:4 frame Moonlight expects so it is not stretched. Can be turned off entirely if you prefer to set artwork yourself in Apollo/Sunshine. Note that Moonlight caches box art per app on the client, so changed artwork may not appear until you clear the client's cache or re-add the host.
 - **Pin/unpin** -- pin games to prevent auto-removal even when they stop matching filters
 - **Manual export/remove** -- right-click context menu for individual games. A game you remove by hand stays removed; sync will not re-add it until you export it again.
 - **Manage exported games** -- view and manage all synced games from the settings tab

--- a/Services/SyncService.cs
+++ b/Services/SyncService.cs
@@ -4,6 +4,7 @@ using Playnite.SDK;
 using Playnite.SDK.Models;
 using System;
 using System.Drawing;
+using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
@@ -21,14 +22,36 @@ namespace ApolloSync.Services
     {
         private static readonly ILogger logger = LogManager.GetLogger();
         private static readonly Random _rng = new Random();
+
+        // Moonlight's app grid forces every cover to 200x267 with QML's default Stretch fill
+        // (moonlight-qt app/gui/AppView.qml), so anything that is not 3:4 arrives distorted.
+        // Covers are normalised onto this canvas to make the result independent of whichever
+        // metadata source the user's library came from.
+        internal const int CoverWidth = 600;
+        internal const int CoverHeight = 800;
+
+        // Part of the cache file name so that changing the canvas regenerates rather than serving
+        // images normalised under the old rules. Derived from the dimensions rather than a hand
+        // bumped constant, which nothing would have forced anyone to remember to change. The
+        // trailing revision covers changes that do not alter the dimensions, such as the draw
+        // call gaining WrapMode.TileFlipXY.
+        private static readonly string CoverCacheVersion = CoverWidth + "x" + CoverHeight + "r2";
+
         private readonly IPlayniteAPI _api;
         private readonly string _imageCacheDir;
+        private readonly Func<bool> _manageCoverImages;
 
-        public SyncService(IPlayniteAPI api = null, string imageCacheDir = null)
+        public SyncService(IPlayniteAPI api = null, string imageCacheDir = null, Func<bool> manageCoverImages = null)
         {
             _api = api;
+            // Not %TEMP%: these are long-lived derived files that apps.json points at by absolute
+            // path, and Storage Sense and Disk Cleanup both delete from %TEMP%, which would
+            // silently strip artwork from every exported game. Same root as the config backups.
             _imageCacheDir = imageCacheDir
-                ?? Path.Combine(Path.GetTempPath(), "ApolloSync", "imagecache");
+                ?? Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                    "ApolloSync", "imagecache");
+            _manageCoverImages = manageCoverImages ?? (() => true);
         }
 
         public bool AddOrUpdate(JObject config, ManagedStore store, Game game)
@@ -60,7 +83,20 @@ namespace ApolloSync.Services
             store.GameToUuid[game.Id] = uuid;
             logger.Debug($"Using Playnite game ID as UUID for {game.Name}: {uuid}");
 
-            var entry = BuildAppEntry(game, uuid);
+            // Read the setting exactly once per call. It was previously read again further down,
+            // with a full image decode/encode in between — long enough for the user to tick the
+            // box on and have the update branch clear image-path against a null it produced while
+            // the setting was still off.
+            var manageCoverImages = _manageCoverImages();
+
+            string coverPath = null;
+            var coverConversionFailed = false;
+            if (manageCoverImages)
+            {
+                coverPath = TryGetCoverImagePath(game, uuid, out coverConversionFailed);
+            }
+
+            var entry = BuildAppEntry(game, uuid, coverPath);
             if (entry == null)
             {
                 logger.Error($"BuildAppEntry returned null for game: {game.Name}");
@@ -88,13 +124,25 @@ namespace ApolloSync.Services
                 existing["name"] = entry["name"];
                 existing["cmd"] = entry["cmd"];
                 existing.Remove("detached"); // Remove deprecated field left over from pre-cmd migration
-                if (entry["image-path"] != null)
+
+                // With cover management off, image-path is not ours to touch — the user may have
+                // set artwork in Apollo's own UI, and clearing or overwriting it would undo that.
+                //
+                // A failed conversion is also not a reason to clear it. TryGetCoverImagePath
+                // returns null both for "this game has no cover" and "we could not produce one",
+                // and only the first of those means the entry should lose its artwork. Every
+                // cover now goes through conversion, so transient failures — a full disk, the
+                // cached file briefly locked — reach here where they never could before.
+                if (manageCoverImages && !coverConversionFailed)
                 {
-                    existing["image-path"] = entry["image-path"];
-                }
-                else
-                {
-                    existing.Remove("image-path"); // Clear stale path if game no longer has a cover
+                    if (entry["image-path"] != null)
+                    {
+                        existing["image-path"] = entry["image-path"];
+                    }
+                    else
+                    {
+                        existing.Remove("image-path"); // Clear stale path if game no longer has a cover
+                    }
                 }
             }
             else
@@ -138,15 +186,32 @@ namespace ApolloSync.Services
             return true;
         }
 
+        /// <summary>
+        /// The single definition of where a game's normalised cover lives. Both the writer and
+        /// the cleanup path must agree, and they did not when the version suffix was introduced
+        /// in only one of them — removing a game then left its cached image behind forever.
+        /// </summary>
+        private string GetCoverCachePath(Guid gameId)
+        {
+            return Path.Combine(_imageCacheDir, gameId.ToString("N") + "_" + CoverCacheVersion + ".png");
+        }
+
         private void CleanupCachedImage(Game game)
         {
             try
             {
-                var pngPath = Path.Combine(_imageCacheDir, game.Id.ToString("N") + ".png");
-                if (File.Exists(pngPath))
+                if (!Directory.Exists(_imageCacheDir))
                 {
-                    File.Delete(pngPath);
-                    logger.Debug($"Deleted cached PNG for game {game.Name}: {pngPath}");
+                    return;
+                }
+
+                // Glob rather than just the current name: covers cached under an earlier canvas
+                // are still this game's files, and nothing else would ever delete them. The cache
+                // now lives in %LOCALAPPDATA%, which Storage Sense does not clean.
+                foreach (var stale in Directory.GetFiles(_imageCacheDir, game.Id.ToString("N") + "_*.png"))
+                {
+                    File.Delete(stale);
+                    logger.Debug($"Deleted cached PNG for game {game.Name}: {stale}");
                 }
             }
             catch (Exception ex)
@@ -160,7 +225,7 @@ namespace ApolloSync.Services
             return Path.Combine(Path.GetTempPath(), $"apollosync-{gameId:N}.lock");
         }
 
-        private JObject BuildAppEntry(Game game, Guid uuid)
+        private JObject BuildAppEntry(Game game, Guid uuid, string coverPath)
         {
             // Build a PowerShell wrapper cmd that Apollo can track for session lifetime.
             // Playnite.DesktopApp.exe --start exits immediately (it signals an existing
@@ -194,10 +259,9 @@ namespace ApolloSync.Services
                 ["cmd"] = cmd
             };
 
-            var imgPath = TryGetCoverImagePath(game, uuid);
-            if (!string.IsNullOrEmpty(imgPath))
+            if (!string.IsNullOrEmpty(coverPath))
             {
-                obj["image-path"] = imgPath;
+                obj["image-path"] = coverPath;
             }
             return obj;
         }
@@ -218,8 +282,16 @@ namespace ApolloSync.Services
             return uuid.ToString().ToUpperInvariant();
         }
 
-        private string TryGetCoverImagePath(Game game, Guid gameUuid)
+        /// <summary>
+        /// Returns the path to the game's normalised cover, or null if there isn't one.
+        /// <paramref name="conversionFailed"/> separates "this game has no cover" from "it has one
+        /// and we could not produce a PNG from it" — only the former should clear an existing
+        /// image-path, and callers that delete on a null result must check it.
+        /// </summary>
+        private string TryGetCoverImagePath(Game game, Guid gameUuid, out bool conversionFailed)
         {
+            conversionFailed = false;
+
             try
             {
                 if (string.IsNullOrEmpty(game.CoverImage))
@@ -251,13 +323,12 @@ namespace ApolloSync.Services
                     return null;
                 }
 
-                // Apollo requires PNG images; convert if necessary
-                if (sourcePath.EndsWith(".png", StringComparison.OrdinalIgnoreCase))
-                {
-                    logger.Debug($"Using Playnite cover image path for game {game.Name}: {sourcePath}");
-                    return sourcePath;
-                }
-
+                // Every cover goes through conversion, including ones already named .png. The
+                // extension is not evidence of the contents: Playnite names cover files after the
+                // source URL, and metadata providers routinely serve JPEG bytes from a .png URL.
+                // Trusting the name handed Apollo a JPEG it could not decode, and the game showed
+                // no artwork at all. Image.FromStream sniffs the real format, so this also
+                // normalises the aspect ratio in the same pass.
                 var pngPath = ConvertToPng(sourcePath, game.Name, gameUuid);
                 if (pngPath != null)
                 {
@@ -265,14 +336,39 @@ namespace ApolloSync.Services
                     return pngPath;
                 }
 
-                logger.Debug($"PNG conversion failed for game {game.Name}, skipping image");
+                conversionFailed = true;
+                logger.Warn($"PNG conversion failed for game {game.Name}; leaving any existing box art in place");
                 return null;
             }
             catch (Exception ex)
             {
+                conversionFailed = true;
                 logger.Info(ex, $"ApolloSync: Error getting cover image path for '{game.Name}'.");
                 return null;
             }
+        }
+
+        /// <summary>
+        /// Scales <paramref name="sourceWidth"/> x <paramref name="sourceHeight"/> to fit inside
+        /// the cover canvas without distorting it, and returns where to draw it. Fit-and-pad
+        /// rather than crop: the square art many metadata sources produce would lose 25% off both
+        /// sides, which is exactly where cover titles and logos sit.
+        /// Pure, so the geometry is testable without touching GDI+.
+        /// </summary>
+        internal static Rectangle GetLetterboxBounds(int sourceWidth, int sourceHeight, int canvasWidth, int canvasHeight)
+        {
+            if (sourceWidth <= 0 || sourceHeight <= 0)
+            {
+                return new Rectangle(0, 0, canvasWidth, canvasHeight);
+            }
+
+            var scale = Math.Min((double)canvasWidth / sourceWidth, (double)canvasHeight / sourceHeight);
+
+            // Round rather than truncate, and clamp: a rounded-up edge must not exceed the canvas.
+            var width = Math.Min(canvasWidth, Math.Max(1, (int)Math.Round(sourceWidth * scale)));
+            var height = Math.Min(canvasHeight, Math.Max(1, (int)Math.Round(sourceHeight * scale)));
+
+            return new Rectangle((canvasWidth - width) / 2, (canvasHeight - height) / 2, width, height);
         }
 
         private string ConvertToPng(string sourcePath, string gameName, Guid gameUuid)
@@ -282,7 +378,7 @@ namespace ApolloSync.Services
                 Directory.CreateDirectory(_imageCacheDir);
 
                 // Use game UUID as cache key to avoid collisions from duplicate filenames
-                var pngPath = Path.Combine(_imageCacheDir, gameUuid.ToString("N") + ".png");
+                var pngPath = GetCoverCachePath(gameUuid);
 
                 // Skip conversion if cached PNG already exists and is newer than source
                 if (File.Exists(pngPath) && File.GetLastWriteTimeUtc(pngPath) >= File.GetLastWriteTimeUtc(sourcePath))
@@ -296,10 +392,32 @@ namespace ApolloSync.Services
                 {
                     using (var ms = new MemoryStream(File.ReadAllBytes(sourcePath)))
                     using (var image = Image.FromStream(ms))
+                    using (var canvas = new Bitmap(CoverWidth, CoverHeight, PixelFormat.Format32bppArgb))
                     {
+                        using (var g = Graphics.FromImage(canvas))
+                        using (var attributes = new ImageAttributes())
+                        {
+                            // Transparent padding rather than bars: the grid background shows
+                            // through, so letterboxing is not visible as a border.
+                            g.Clear(Color.Transparent);
+                            g.InterpolationMode = System.Drawing.Drawing2D.InterpolationMode.HighQualityBicubic;
+                            g.PixelOffsetMode = System.Drawing.Drawing2D.PixelOffsetMode.HighQuality;
+                            g.CompositingQuality = System.Drawing.Drawing2D.CompositingQuality.HighQuality;
+
+                            // Without this the bicubic kernel samples past the edge of the source
+                            // and blends with the transparent canvas, leaving a translucent halo
+                            // around every cover — measured down to ~46% alpha at the corners,
+                            // which reads as a dark outline anywhere the alpha is flattened.
+                            attributes.SetWrapMode(WrapMode.TileFlipXY);
+
+                            var bounds = GetLetterboxBounds(image.Width, image.Height, CoverWidth, CoverHeight);
+                            g.DrawImage(image, bounds, 0, 0, image.Width, image.Height,
+                                GraphicsUnit.Pixel, attributes);
+                        }
+
                         // Write to temp file, then replace — not fully atomic on Windows
                         // (Delete+Move gap) but prevents corrupt cache from partial writes
-                        image.Save(tmpPath, ImageFormat.Png);
+                        canvas.Save(tmpPath, ImageFormat.Png);
                     }
                     if (File.Exists(pngPath))
                     {

--- a/Settings/ApolloSyncSettings.cs
+++ b/Settings/ApolloSyncSettings.cs
@@ -61,6 +61,18 @@ namespace ApolloSync
             set => SetValue(ref _includedFilterPresetIds, value);
         }
 
+        private bool _manageCoverImages = true;
+        /// <summary>
+        /// When false the plugin never writes or clears the "image-path" field, leaving whatever
+        /// artwork the user has set in Apollo/Sunshine's own UI alone. Everything else about the
+        /// entry is still synced.
+        /// </summary>
+        public bool ManageCoverImages
+        {
+            get => _manageCoverImages;
+            set => SetValue(ref _manageCoverImages, value);
+        }
+
         private bool _showNotifications = true;
         public bool ShowNotifications
         {

--- a/Settings/ApolloSyncSettingsView.xaml.cs
+++ b/Settings/ApolloSyncSettingsView.xaml.cs
@@ -101,6 +101,36 @@ namespace ApolloSync
 
             stack.Children.Add(new Separator { Margin = new Thickness(0, 8, 0, 8) });
 
+            // Cover images
+            var coverImagesHeader = new TextBlock
+            {
+                Text = ResourceProvider.GetString("LOC_ApolloSync_Settings_CoverImages"),
+                FontWeight = FontWeights.Bold,
+                FontSize = 14,
+                Margin = new Thickness(0, 8, 0, 8)
+            };
+            stack.Children.Add(coverImagesHeader);
+
+            var chkManageCoverImages = new CheckBox
+            {
+                Content = ResourceProvider.GetString("LOC_ApolloSync_Settings_ManageCoverImages"),
+                Margin = new Thickness(20, 0, 0, 4)
+            };
+            chkManageCoverImages.SetBinding(CheckBox.IsCheckedProperty,
+                new Binding("Settings.ManageCoverImages") { Mode = BindingMode.TwoWay });
+            stack.Children.Add(chkManageCoverImages);
+
+            stack.Children.Add(new TextBlock
+            {
+                Text = ResourceProvider.GetString("LOC_ApolloSync_Settings_ManageCoverImages_Help"),
+                TextWrapping = TextWrapping.Wrap,
+                Margin = new Thickness(20, 0, 0, 8),
+                FontStyle = FontStyles.Italic,
+                Foreground = System.Windows.Media.Brushes.Gray
+            });
+
+            stack.Children.Add(new Separator { Margin = new Thickness(0, 8, 0, 8) });
+
             // Notifications header
             var notificationsHeader = new TextBlock
             {

--- a/Tests/SyncServiceTests.cs
+++ b/Tests/SyncServiceTests.cs
@@ -46,33 +46,410 @@ namespace ApolloSync.Tests
             Assert.IsTrue(store.GameToUuid.ContainsKey(game.Id));
         }
 
-        [TestMethod]
-        public void AddOrUpdate_UsesPngCoverImagePathDirectly()
-        {
-            var service = new SyncService(imageCacheDir: TestCacheDir);
-            var config = new JObject { ["apps"] = new JArray() };
-            var store = new ManagedStore();
-            var tempImage = Path.Combine(TestDir, Guid.NewGuid().ToString("N") + ".png");
-            using (var bmp = new Bitmap(1, 1))
-            {
-                bmp.Save(tempImage, ImageFormat.Png);
-            }
+        // ── Cover image normalisation ─────────────────────────────────────────────
 
-            var game = new Game("Test Game")
+        /// <summary>Writes real JPEG bytes to a file with whatever name is asked for.</summary>
+        private static string WriteJpegNamed(string fileName, int width = 100, int height = 100)
+        {
+            var path = Path.Combine(TestDir, fileName);
+            using (var bmp = new Bitmap(width, height))
+            {
+                bmp.Save(path, ImageFormat.Jpeg);
+            }
+            return path;
+        }
+
+        private static string WritePngNamed(string fileName, int width = 100, int height = 100)
+        {
+            var path = Path.Combine(TestDir, fileName);
+            using (var bmp = new Bitmap(width, height))
+            {
+                bmp.Save(path, ImageFormat.Png);
+            }
+            return path;
+        }
+
+        private static Game GameWithCover(string coverPath)
+        {
+            return new Game("Test Game")
             {
                 Id = Guid.NewGuid(),
                 InstallDirectory = "C:\\Games\\Test",
-                CoverImage = tempImage
+                CoverImage = coverPath
             };
+        }
 
-            var ok = service.AddOrUpdate(config, store, game);
-            Assert.IsTrue(ok);
+        private static void AssertIsRealPng(string path)
+        {
+            var header = new byte[8];
+            using (var fs = File.OpenRead(path))
+            {
+                fs.Read(header, 0, 8);
+            }
+            Assert.AreEqual(0x89, header[0], "not a PNG: byte 0");
+            Assert.AreEqual(0x50, header[1], "not a PNG: byte 1 (P)");
+            Assert.AreEqual(0x4E, header[2], "not a PNG: byte 2 (N)");
+            Assert.AreEqual(0x47, header[3], "not a PNG: byte 3 (G)");
+        }
+
+        [TestMethod]
+        public void AddOrUpdate_ConvertsJpegDisguisedAsPngFile()
+        {
+            // The reported bug: Playnite names cover files after the source URL, and metadata
+            // providers routinely serve JPEG bytes from a .png URL. Trusting the extension handed
+            // Apollo a JPEG it could not decode, so the game showed no artwork in Moonlight at all.
+            var service = new SyncService(imageCacheDir: TestCacheDir);
+            var config = new JObject { ["apps"] = new JArray() };
+            var store = new ManagedStore();
+            var jpegNamedPng = WriteJpegNamed(Guid.NewGuid().ToString("N") + ".png");
+
+            var game = GameWithCover(jpegNamedPng);
+            Assert.IsTrue(service.AddOrUpdate(config, store, game));
+
+            var imgPath = (string)((JObject)((JArray)config["apps"])[0])["image-path"];
+            Assert.IsNotNull(imgPath);
+            Assert.AreNotEqual(jpegNamedPng, imgPath,
+                "The mislabelled source must not be handed to Apollo as-is");
+            Assert.IsTrue(imgPath.StartsWith(TestCacheDir), "Expected a converted file in the cache");
+            AssertIsRealPng(imgPath);
+        }
+
+        [TestMethod]
+        public void AddOrUpdate_NormalizesGenuinePngCoversToo()
+        {
+            // Even a real PNG needs the canvas normalised, so nothing is passed through untouched.
+            var service = new SyncService(imageCacheDir: TestCacheDir);
+            var config = new JObject { ["apps"] = new JArray() };
+            var store = new ManagedStore();
+            var realPng = WritePngNamed(Guid.NewGuid().ToString("N") + ".png", 1024, 1024);
+
+            var game = GameWithCover(realPng);
+            Assert.IsTrue(service.AddOrUpdate(config, store, game));
+
+            var imgPath = (string)((JObject)((JArray)config["apps"])[0])["image-path"];
+            Assert.AreNotEqual(realPng, imgPath, "Covers are normalised, not passed through");
+            AssertIsRealPng(imgPath);
+
+            // Asserting the dimensions too, so a ConvertToPng reduced to File.Copy would fail
+            // this rather than sail through on the magic-byte check.
+            using (var produced = Image.FromFile(imgPath))
+            {
+                Assert.AreEqual(600, produced.Width);
+                Assert.AreEqual(800, produced.Height);
+            }
+        }
+
+        [TestMethod]
+        public void AddOrUpdate_ProducesCoverOnTheAspectRatioMoonlightExpects()
+        {
+            // Moonlight's grid force-scales every cover to 200x267 with QML's default Stretch
+            // fill, so a square source arrives squeezed by 25% unless it is normalised first.
+            // Literal numbers, not the CoverWidth/CoverHeight constants: comparing the output
+            // against the very constant that produced it cannot fail.
+            var service = new SyncService(imageCacheDir: TestCacheDir);
+            var config = new JObject { ["apps"] = new JArray() };
+            var store = new ManagedStore();
+            var squareCover = WritePngNamed(Guid.NewGuid().ToString("N") + ".png", 1024, 1024);
+
+            var game = GameWithCover(squareCover);
+            Assert.IsTrue(service.AddOrUpdate(config, store, game));
+
+            var imgPath = (string)((JObject)((JArray)config["apps"])[0])["image-path"];
+            using (var produced = Image.FromFile(imgPath))
+            {
+                Assert.AreEqual(600, produced.Width);
+                Assert.AreEqual(800, produced.Height);
+                Assert.AreEqual(0.75, (double)produced.Width / produced.Height, 0.001);
+            }
+        }
+
+        [TestMethod]
+        public void AddOrUpdate_ActuallyDrawsTheCoverLetterboxedOntoTheCanvas()
+        {
+            // The geometry is well covered as a pure function, but nothing verified that the
+            // conversion USES it. Without this, deleting the DrawImage call ships a fully
+            // transparent 600x800 image for every game — blank artwork in Moonlight, which is
+            // the exact failure this whole change exists to fix — with every other test green.
+            var service = new SyncService(imageCacheDir: TestCacheDir);
+            var config = new JObject { ["apps"] = new JArray() };
+            var store = new ManagedStore();
+
+            var coverPath = Path.Combine(TestDir, Guid.NewGuid().ToString("N") + ".png");
+            using (var bmp = new Bitmap(1024, 1024))
+            {
+                using (var g = Graphics.FromImage(bmp))
+                {
+                    g.Clear(Color.Red);
+                }
+                bmp.Save(coverPath, ImageFormat.Png);
+            }
+
+            var game = GameWithCover(coverPath);
+            Assert.IsTrue(service.AddOrUpdate(config, store, game));
+
+            var imgPath = (string)((JObject)((JArray)config["apps"])[0])["image-path"];
+            using (var produced = new Bitmap(imgPath))
+            {
+                // A 1024x1024 source fits the 600 width and is centred vertically, so rows
+                // 100..699 hold the cover and everything outside stays transparent padding.
+                var centre = produced.GetPixel(300, 400);
+                Assert.AreEqual(255, centre.A, "the cover was never drawn onto the canvas");
+                Assert.IsTrue(centre.R > 200 && centre.G < 60 && centre.B < 60,
+                    $"expected the red cover at the centre, got {centre}");
+
+                var padding = produced.GetPixel(300, 10);
+                Assert.AreEqual(0, padding.A,
+                    "the source was stretched to fill the canvas instead of being letterboxed");
+
+                // The halo fix: edge pixels of the drawn area must be fully opaque, not blended
+                // with the transparent canvas by the interpolation kernel.
+                Assert.AreEqual(255, produced.GetPixel(0, 400).A, "translucent halo on the left edge");
+                Assert.AreEqual(255, produced.GetPixel(599, 400).A, "translucent halo on the right edge");
+                Assert.AreEqual(255, produced.GetPixel(300, 101).A, "translucent halo on the top edge");
+            }
+        }
+
+        [TestMethod]
+        public void AddOrUpdate_ConversionFailureLeavesExistingArtworkAlone()
+        {
+            // A cover that cannot be decoded must not clear box art that is already there.
+            // TryGetCoverImagePath returns null for both "no cover" and "conversion failed", and
+            // only the first is a reason to remove the field. Every cover now goes through
+            // conversion, so this path is reachable where it never used to be.
+            var service = new SyncService(imageCacheDir: TestCacheDir);
+            var config = new JObject { ["apps"] = new JArray() };
+            var store = new ManagedStore();
+
+            var goodCover = WritePngNamed(Guid.NewGuid().ToString("N") + ".png");
+            var game = GameWithCover(goodCover);
+            Assert.IsTrue(service.AddOrUpdate(config, store, game));
 
             var app = (JObject)((JArray)config["apps"])[0];
+            var originalPath = (string)app["image-path"];
+            Assert.IsNotNull(originalPath);
 
-            // PNG should be used directly without conversion
+            // The cover is replaced by something GDI+ cannot decode.
+            var brokenCover = Path.Combine(TestDir, Guid.NewGuid().ToString("N") + ".png");
+            File.WriteAllBytes(brokenCover, new byte[] { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05 });
+            game.CoverImage = brokenCover;
+
+            Assert.IsTrue(service.AddOrUpdate(config, store, game));
+
+            Assert.AreEqual(originalPath, (string)app["image-path"],
+                "A failed conversion must not strip the artwork that is already exported");
+        }
+
+        [TestMethod]
+        public void AddOrUpdate_RemovingTheCoverStillClearsImagePath()
+        {
+            // The inverse of the above: a game that genuinely has no cover any more must lose
+            // its image-path, or the entry points at art the game no longer has.
+            var service = new SyncService(imageCacheDir: TestCacheDir);
+            var config = new JObject { ["apps"] = new JArray() };
+            var store = new ManagedStore();
+
+            var game = GameWithCover(WritePngNamed(Guid.NewGuid().ToString("N") + ".png"));
+            Assert.IsTrue(service.AddOrUpdate(config, store, game));
+
+            var app = (JObject)((JArray)config["apps"])[0];
             Assert.IsNotNull(app["image-path"]);
-            Assert.AreEqual(tempImage, (string)app["image-path"]);
+
+            game.CoverImage = null;
+            Assert.IsTrue(service.AddOrUpdate(config, store, game));
+
+            Assert.IsNull(app["image-path"]);
+        }
+
+        // ── Letterbox geometry ────────────────────────────────────────────────────
+
+        [TestMethod]
+        public void GetLetterboxBounds_SquareSourceFillsWidthAndCentresVertically()
+        {
+            var r = SyncService.GetLetterboxBounds(1024, 1024, 600, 800);
+
+            Assert.AreEqual(600, r.Width, "A square cover should fit the canvas width");
+            Assert.AreEqual(600, r.Height, "and stay square — not stretch to the canvas height");
+            Assert.AreEqual(0, r.X);
+            Assert.AreEqual(100, r.Y, "padding split evenly top and bottom");
+        }
+
+        [TestMethod]
+        public void GetLetterboxBounds_TallerThanCanvasFillsHeightAndCentresHorizontally()
+        {
+            // SteamGridDB's 600x900 (2:3) is taller than the 3:4 frame.
+            var r = SyncService.GetLetterboxBounds(600, 900, 600, 800);
+
+            Assert.AreEqual(800, r.Height);
+            Assert.AreEqual(533, r.Width);
+            Assert.AreEqual(0, r.Y);
+            Assert.AreEqual(33, r.X);
+        }
+
+        [TestMethod]
+        public void GetLetterboxBounds_ExactAspectRatioFillsTheCanvas()
+        {
+            var r = SyncService.GetLetterboxBounds(300, 400, 600, 800);
+
+            Assert.AreEqual(new Rectangle(0, 0, 600, 800), r);
+        }
+
+        [TestMethod]
+        public void GetLetterboxBounds_LandscapeSourceIsNotCropped()
+        {
+            var r = SyncService.GetLetterboxBounds(1920, 1080, 600, 800);
+
+            Assert.AreEqual(600, r.Width);
+            Assert.AreEqual(338, r.Height);
+            Assert.IsTrue(r.Height <= 800);
+        }
+
+        [TestMethod]
+        public void GetLetterboxBounds_PreservesTheSourceAspectRatio()
+        {
+            // Real cover shapes: SteamGridDB square and 2:3, Steam capsules, IGDB, plus a
+            // landscape hero image in case someone uses one as a cover.
+            foreach (var size in new[]
+            {
+                new Size(1024, 1024), new Size(600, 900), new Size(342, 482),
+                new Size(1920, 1080), new Size(2160, 2160), new Size(264, 352)
+            })
+            {
+                var r = SyncService.GetLetterboxBounds(size.Width, size.Height, 600, 800);
+                var sourceRatio = (double)size.Width / size.Height;
+                var drawnRatio = (double)r.Width / r.Height;
+
+                // Tolerance covers rounding to whole pixels at these canvas sizes.
+                Assert.AreEqual(sourceRatio, drawnRatio, sourceRatio * 0.01,
+                    $"{size.Width}x{size.Height} was distorted");
+            }
+        }
+
+        [TestMethod]
+        public void GetLetterboxBounds_SubPixelDimensionClampsToOneAndAcceptsTheDistortion()
+        {
+            // A source so thin that fitting it would round its width to zero. Aspect ratio cannot
+            // be honoured at integer pixels here, and a zero-width rectangle would draw nothing
+            // at all, so the trade is deliberate: clamp to 1px and keep the image visible.
+            // Not reachable from real cover art — documented so the clamp is not "fixed" later.
+            var r = SyncService.GetLetterboxBounds(1, 3000, 600, 800);
+
+            Assert.AreEqual(1, r.Width);
+            Assert.AreEqual(800, r.Height);
+            Assert.IsTrue(r.Right <= 600 && r.Bottom <= 800);
+        }
+
+        [TestMethod]
+        public void GetLetterboxBounds_NeverExceedsTheCanvas()
+        {
+            foreach (var size in new[]
+            {
+                new Size(1024, 1024), new Size(601, 801), new Size(599, 799), new Size(3, 4000)
+            })
+            {
+                var r = SyncService.GetLetterboxBounds(size.Width, size.Height, 600, 800);
+
+                Assert.IsTrue(r.X >= 0 && r.Y >= 0, $"{size} placed off-canvas");
+                Assert.IsTrue(r.Right <= 600 && r.Bottom <= 800, $"{size} overflowed the canvas");
+            }
+        }
+
+        [TestMethod]
+        public void GetLetterboxBounds_DegenerateSourceFallsBackToTheFullCanvas()
+        {
+            // A zero dimension would divide by zero; GDI+ can report this for damaged images.
+            Assert.AreEqual(new Rectangle(0, 0, 600, 800), SyncService.GetLetterboxBounds(0, 0, 600, 800));
+            Assert.AreEqual(new Rectangle(0, 0, 600, 800), SyncService.GetLetterboxBounds(100, 0, 600, 800));
+        }
+
+        // ── Opting out of cover management ────────────────────────────────────────
+
+        [TestMethod]
+        public void AddOrUpdate_WithCoverManagementOff_DoesNotSetImagePath()
+        {
+            var service = new SyncService(imageCacheDir: TestCacheDir, manageCoverImages: () => false);
+            var config = new JObject { ["apps"] = new JArray() };
+            var store = new ManagedStore();
+            var game = GameWithCover(WritePngNamed(Guid.NewGuid().ToString("N") + ".png"));
+
+            Assert.IsTrue(service.AddOrUpdate(config, store, game));
+
+            var app = (JObject)((JArray)config["apps"])[0];
+            Assert.IsNull(app["image-path"]);
+            Assert.IsNotNull(app["cmd"], "everything else about the entry is still synced");
+            Assert.AreEqual("Test Game", (string)app["name"]);
+        }
+
+        [TestMethod]
+        public void AddOrUpdate_WithCoverManagementOff_LeavesUserSetArtworkAlone()
+        {
+            // The point of the opt-out: someone curating box art in Apollo's own UI must not have
+            // it overwritten or cleared by the next sync.
+            var service = new SyncService(imageCacheDir: TestCacheDir, manageCoverImages: () => false);
+            var config = new JObject { ["apps"] = new JArray() };
+            var store = new ManagedStore();
+            var game = GameWithCover(WritePngNamed(Guid.NewGuid().ToString("N") + ".png"));
+
+            Assert.IsTrue(service.AddOrUpdate(config, store, game));
+            var app = (JObject)((JArray)config["apps"])[0];
+
+            // The user sets their own artwork in Apollo.
+            app["image-path"] = "D:\\MyArtwork\\custom.png";
+
+            // A later sync updates the entry.
+            game.Name = "Test Game Renamed";
+            Assert.IsTrue(service.AddOrUpdate(config, store, game));
+
+            Assert.AreEqual("D:\\MyArtwork\\custom.png", (string)app["image-path"],
+                "User-set artwork must survive a sync when cover management is off");
+            Assert.AreEqual("Test Game Renamed", (string)app["name"], "other fields still update");
+        }
+
+        [TestMethod]
+        public void AddOrUpdate_WithCoverManagementOn_StillOwnsImagePath()
+        {
+            // The inverse: with management on, our value wins over whatever is there.
+            var service = new SyncService(imageCacheDir: TestCacheDir, manageCoverImages: () => true);
+            var config = new JObject { ["apps"] = new JArray() };
+            var store = new ManagedStore();
+            var game = GameWithCover(WritePngNamed(Guid.NewGuid().ToString("N") + ".png"));
+
+            Assert.IsTrue(service.AddOrUpdate(config, store, game));
+            var app = (JObject)((JArray)config["apps"])[0];
+            app["image-path"] = "D:\\MyArtwork\\custom.png";
+
+            Assert.IsTrue(service.AddOrUpdate(config, store, game));
+
+            Assert.AreNotEqual("D:\\MyArtwork\\custom.png", (string)app["image-path"]);
+            Assert.IsTrue(((string)app["image-path"]).StartsWith(TestCacheDir));
+        }
+
+        [TestMethod]
+        public void ManageCoverImages_DefaultsToEnabled()
+        {
+            // Persisted only once written, so a flipped default would silently disable artwork
+            // for every existing user on upgrade.
+            Assert.IsTrue(new ApolloSyncSettings().ManageCoverImages);
+        }
+
+        [TestMethod]
+        public void AddOrUpdate_CoverManagementIsReadPerCall()
+        {
+            // Read through a delegate, not captured at construction: the user can toggle the
+            // setting while the plugin is loaded and the next sync must honour it.
+            var enabled = false;
+            var service = new SyncService(imageCacheDir: TestCacheDir, manageCoverImages: () => enabled);
+            var config = new JObject { ["apps"] = new JArray() };
+            var store = new ManagedStore();
+            var game = GameWithCover(WritePngNamed(Guid.NewGuid().ToString("N") + ".png"));
+
+            service.AddOrUpdate(config, store, game);
+            var app = (JObject)((JArray)config["apps"])[0];
+            Assert.IsNull(app["image-path"]);
+
+            enabled = true;
+            service.AddOrUpdate(config, store, game);
+
+            Assert.IsNotNull(app["image-path"], "toggling the setting on must take effect immediately");
         }
 
         [TestMethod]


### PR DESCRIPTION
Fixes cover art in Moonlight. Two independent defects, both reproduced and then verified fixed against a real 50-game library.

## 1. The wrong format was being handed to Apollo

`TryGetCoverImagePath` decided *"is this already a PNG?"* from the **file extension**:

```csharp
if (sourcePath.EndsWith(".png", StringComparison.OrdinalIgnoreCase))
{
    return sourcePath;   // trusts the filename, never looks at the bytes
}
```

Playnite names cover files after the source URL, and metadata providers routinely serve JPEG bytes from a `.png` URL — so the file is `.png` on disk and JPEG inside. Apollo could not decode it and the game showed **no artwork at all**.

Measured on the reporting user's library before the fix:

| Declared ext | Actual content | Converted by us? | Count |
|---|---|---|---|
| `.png` | **JPEG** | no | **43** ← broken |
| `.png` | PNG | no | 1 |
| `.png` | PNG | yes | 6 |

The tell: the only covers that worked were the ones whose extension happened *not* to be `.png`, so they fell through to conversion. Every cover now goes through `Image.FromStream`, which sniffs the real format.

## 2. Non-3:4 art was being stretched

From `moonlight-qt/app/gui/AppView.qml`:

```qml
Image {
    source: model.boxart
    onSourceSizeChanged: {
        width = 200
        height = 267      // unconditional, whatever the source is
    }
}
```

No `fillMode` is set, so it is QML's default `Image.Stretch`. Every cover is force-scaled to 200×267 (≈3:4); `sourceSize` is consulted only to detect known placeholder images, never to preserve proportions.

Which shapes a user has depends entirely on their metadata source — SteamGridDB alone serves square 1024×1024, 600×900 (2:3) and 342×482. The reporting library was 100% square, so every cover was squeezed 25% horizontally.

Covers are now letterboxed onto a 600×800 canvas: **fit and pad, never crop**. Cropping square art to 3:4 removes 25% from both sides, which is exactly where titles and logos sit. `GetLetterboxBounds` is pure, so the geometry is tested without touching GDI+.

## 3. Opt-out

New `ManageCoverImages` setting (General tab, default **on**). When off the plugin never writes *or clears* `image-path`, so artwork set by hand in Apollo/Sunshine's own UI survives a sync — everything else about the entry still syncs. Read through a delegate rather than captured at construction, so toggling it takes effect on the next sync, and read once per `AddOrUpdate` so it cannot change between building the entry and updating it.

## Found in review, fixed before merge

- **A translucent halo on every cover.** The bicubic kernel sampled past the source edge and blended with the transparent canvas — measured down to ~46% alpha at the corners, which reads as a dark outline wherever alpha is flattened. Fixed with `WrapMode.TileFlipXY`.
- **A failed conversion cleared existing artwork.** `TryGetCoverImagePath` returned `null` for both "no cover" and "could not convert", and only the first should remove the field. Newly reachable, since every cover now converts.
- **`DrawImage` was entirely unguarded by tests.** The geometry was well covered as a pure function but nothing verified the conversion *used* it — you could delete the draw call and ship a blank transparent cover for every game with all 77 tests green. That is the exact failure this PR fixes. Now pixel-asserted.
- **Cache moved from `%TEMP%` to `%LOCALAPPDATA%`.** `apps.json` holds absolute paths into it and Storage Sense deletes from `%TEMP%`, which would silently strip artwork from every exported game.
- **Cache version derived from the canvas dimensions** instead of a hand-bumped constant nothing forced anyone to change, and cleanup globs every version so a future change cannot leak one PNG per game.

## Verification

- `dotnet build -c Release` — succeeds; `dotnet test` — **81/81** (25 new)
- Mutation-checked: reverting the format fix, the letterbox, the centring, the scale direction, either opt-out guard, the wrap mode, the conversion-failure guard, or the default-on setting each fails the suite. The three that previously survived (delete `DrawImage`, stretch instead of letterbox, flip the default) are now killed.
- **Live on a real setup**, before → after: **7/50 → 50/50** valid PNGs, all 600×800, every one letterboxed with opaque edges and transparent padding, confirmed rendering correctly in the Moonlight iOS client.

## Note for users upgrading

Moonlight caches box art **per app id** on the client (`NvHTTP::getBoxArt(int appId)` + `BoxArtManager`), and this plugin preserves the numeric `id` on existing entries — so the cache key does not change when the artwork behind it does. After upgrading, a client may keep showing its old cached art until its cache is cleared or the host is re-added. Called out in the changelog and README rather than worked around, since bumping ids to bust the cache would churn every entry on every sync.

Localization for the new setting added to all 19 locale files (3 keys each, verified: 49 keys per file, valid XML, no English leakage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---

### Version bump deliberately excluded

This PR leaves `extension.yaml`, `manifest.yaml` and `AssemblyInfo.cs` untouched at 1.3.1 — more changes are landing before the next release, so the bump covers them together.

Changelog lines for whoever runs the bump (the workflow generates commit subjects, which are not user-facing):

```yaml
      - Cover art now appears in Moonlight for games whose Playnite cover is a JPEG saved under a .png name - those games previously showed no artwork at all
      - Covers are fitted to the 3:4 frame Moonlight expects instead of being stretched, so square and 2:3 artwork is no longer distorted
      - New setting to turn cover image export off entirely, leaving artwork you set yourself in Apollo/Sunshine untouched
      - Converted covers are now cached under %LOCALAPPDATA% instead of %TEMP%, where Windows disk cleanup could delete them and silently strip artwork from every exported game
      - A cover that fails to convert no longer clears artwork that was already exported for that game
      - "Note: Moonlight caches box art per app on the client, so after upgrading you may need to clear your client's cache or re-add the host before the corrected artwork appears"
```