### PR TITLE
Support excluding games from export via filter presets (#30)

### DIFF
--- a/ApolloSync.cs
+++ b/ApolloSync.cs
@@ -529,72 +529,128 @@ namespace ApolloSync
         #endregion
 
         #region Game Filtering
+
         /// <summary>
-        /// Snapshots the selected preset ids. The settings view edits
-        /// <see cref="ApolloSyncSettings.IncludedFilterPresetIds"/> in place on the UI thread as
+        /// Immutable copy of the include/exclude preset id lists for one sync or evaluation.
+        /// Constructor copies both lists so a mid-edit settings mutation cannot race the sync.
+        /// </summary>
+        private sealed class FilterPresetSelection
+        {
+            public List<Guid> Included { get; private set; }
+            public List<Guid> Excluded { get; private set; }
+
+            public FilterPresetSelection(IList<Guid> included, IList<Guid> excluded)
+            {
+                Included = included != null ? new List<Guid>(included) : new List<Guid>();
+                Excluded = excluded != null ? new List<Guid>(excluded) : new List<Guid>();
+            }
+        }
+
+        /// <summary>
+        /// Snapshots the selected include and exclude preset ids. The settings view edits
+        /// <see cref="ApolloSyncSettings.IncludedFilterPresetIds"/> and
+        /// <see cref="ApolloSyncSettings.ExcludedFilterPresetIds"/> in place on the UI thread as
         /// the user ticks boxes — before OK is pressed, and undone only in memory by CancelEdit —
         /// so a sync reading the live list can enumerate it mid-mutation, or observe a transient
         /// empty list and prune everything the user was about to re-select.
         /// </summary>
-        private List<Guid> SnapshotSelectedPresetIds()
+        private FilterPresetSelection SnapshotFilterPresetSelection()
         {
-            var selected = _settings.Settings.IncludedFilterPresetIds;
-            return selected == null ? new List<Guid>() : new List<Guid>(selected);
+            return new FilterPresetSelection(
+                _settings.Settings.IncludedFilterPresetIds,
+                _settings.Settings.ExcludedFilterPresetIds);
         }
 
         private List<Game> GetFilteredGames()
         {
-            return GetFilteredGames(SnapshotSelectedPresetIds());
+            return GetFilteredGames(SnapshotFilterPresetSelection());
         }
 
-        private List<Game> GetFilteredGames(List<Guid> selectedPresetIds)
+        private List<Game> GetFilteredGames(FilterPresetSelection selection)
         {
-            // Use filter presets with OR logic - game matches if it matches ANY selected preset
-            if (selectedPresetIds.Count > 0)
+            // Use filter presets with OR logic - game matches if it matches ANY selected include
+            if (selection.Included.Count == 0)
             {
-                var matchingGames = new HashSet<Game>();
+                // No filter presets selected - return no games
+                logger.Warn("No filter presets selected - no games will be filtered. Please select filter presets in settings.");
+                return new List<Game>();
+            }
 
-                foreach (var presetId in selectedPresetIds)
+            var matchingGames = new HashSet<Game>();
+
+            foreach (var presetId in selection.Included)
+            {
+                var filterPreset = PlayniteApi.Database.FilterPresets
+                    .FirstOrDefault(fp => fp.Id == presetId);
+
+                if (filterPreset?.Settings == null)
                 {
-                    var filterPreset = PlayniteApi.Database.FilterPresets
-                        .FirstOrDefault(fp => fp.Id == presetId);
-
-                    if (filterPreset?.Settings == null)
-                    {
-                        // Logged once per sync here rather than in GameMeetsCurrentFilters, which
-                        // now runs per managed game per sync and would emit this hundreds of times.
-                        logger.Warn($"Selected filter preset {presetId} no longer exists - it was probably deleted in Playnite. No games will be removed while it is missing.");
-                        continue;
-                    }
-
-                    try
-                    {
-                        var presetGames = PlayniteApi.Database.GetFilteredGames(filterPreset.Settings);
-                        foreach (var game in presetGames)
-                        {
-                            matchingGames.Add(game);
-                        }
-                        logger.Debug($"Filter preset '{filterPreset.Name}' matched {presetGames.Count()} games");
-                    }
-                    catch (Exception ex)
-                    {
-                        logger.Error(ex, $"Failed to apply filter preset: {filterPreset.Name}");
-                    }
+                    // Logged once per sync here rather than in GameMeetsCurrentFilters, which
+                    // now runs per managed game per sync and would emit this hundreds of times.
+                    logger.Warn($"Selected filter preset {presetId} no longer exists - it was probably deleted in Playnite. No games will be removed while it is missing.");
+                    continue;
                 }
 
+                try
+                {
+                    var presetGames = PlayniteApi.Database.GetFilteredGames(filterPreset.Settings);
+                    foreach (var game in presetGames)
+                    {
+                        matchingGames.Add(game);
+                    }
+                    logger.Debug($"Filter preset '{filterPreset.Name}' matched {presetGames.Count()} games");
+                }
+                catch (Exception ex)
+                {
+                    logger.Error(ex, $"Failed to apply filter preset: {filterPreset.Name}");
+                }
+            }
+
+            if (selection.Excluded.Count == 0)
+            {
                 logger.Info($"Combined filter presets matched {matchingGames.Count} games");
                 return matchingGames.ToList();
             }
 
-            // No filter presets selected - return no games
-            logger.Warn("No filter presets selected - no games will be filtered. Please select filter presets in settings.");
-            return new List<Game>();
+            var excludedGames = new HashSet<Game>();
+            foreach (var presetId in selection.Excluded)
+            {
+                var filterPreset = PlayniteApi.Database.FilterPresets
+                    .FirstOrDefault(fp => fp.Id == presetId);
+
+                if (filterPreset?.Settings == null)
+                {
+                    // An unresolvable exclude must not mean "excludes nothing" — that would
+                    // silently re-export games the missing preset used to suppress.
+                    logger.Warn($"Excluded filter preset {presetId} no longer exists - it was probably deleted in Playnite. No games will be added while it is missing.");
+                    return new List<Game>();
+                }
+
+                try
+                {
+                    var presetGames = PlayniteApi.Database.GetFilteredGames(filterPreset.Settings);
+                    foreach (var game in presetGames)
+                    {
+                        excludedGames.Add(game);
+                    }
+                    logger.Debug($"Excluded filter preset '{filterPreset.Name}' matched {presetGames.Count()} games");
+                }
+                catch (Exception ex)
+                {
+                    logger.Error(ex, $"Failed to apply excluded filter preset: {filterPreset.Name}. No games will be added while evaluation fails.");
+                    return new List<Game>();
+                }
+            }
+
+            matchingGames.ExceptWith(excludedGames);
+            logger.Info($"Combined filter presets matched {matchingGames.Count} games after exclusions");
+            return matchingGames.ToList();
         }
 
         private bool GameMeetsCurrentFilters(Game game)
         {
             bool evaluationFailed;
-            return GameMeetsCurrentFilters(game, SnapshotSelectedPresetIds(), out evaluationFailed);
+            return GameMeetsCurrentFilters(game, SnapshotFilterPresetSelection(), out evaluationFailed);
         }
 
         /// <summary>
@@ -660,12 +716,49 @@ namespace ApolloSync
         }
 
         /// <summary>
-        /// Evaluates the game against the given filter presets (OR logic). Takes the ids as a
-        /// snapshot rather than reading settings directly — see <see cref="SnapshotSelectedPresetIds"/>.
+        /// Combines include and exclude preset evaluation:
+        /// <c>eligible = (any include match) AND NOT (any exclude match)</c>.
+        /// Exclusion beats inclusion. Pinning is a removal override only (see
+        /// <see cref="ShouldRemoveManagedGame"/>) and does not force a game into the add set.
+        /// Pure apart from the delegate — directly testable without Playnite.
         /// </summary>
-        private bool GameMeetsCurrentFilters(Game game, IList<Guid> selectedPresetIds, out bool evaluationFailed)
+        internal static bool EvaluateExportEligibility(
+            IList<Guid> includedPresetIds,
+            IList<Guid> excludedPresetIds,
+            Func<Guid, bool?> matchPreset,
+            out bool evaluationFailed)
         {
-            return EvaluateFilterPresets(selectedPresetIds, presetId =>
+            bool excludeFailed;
+            bool includeFailed;
+            var excluded = EvaluateFilterPresets(excludedPresetIds, matchPreset, out excludeFailed);
+            var included = EvaluateFilterPresets(includedPresetIds, matchPreset, out includeFailed);
+
+            if (excluded)
+            {
+                // Definite exclusion wins. Clear any sibling-failure flags from either list.
+                evaluationFailed = false;
+                return false;
+            }
+
+            if (included)
+            {
+                // Dangling/throwing exclude must not mean "excludes nothing".
+                evaluationFailed = excludeFailed;
+                return !excludeFailed;
+            }
+
+            // Definite include-miss: dangling exclude cannot resurrect the game.
+            evaluationFailed = includeFailed;
+            return false;
+        }
+
+        /// <summary>
+        /// Evaluates the game against the given include/exclude filter presets. Takes a
+        /// snapshot rather than reading settings directly — see <see cref="SnapshotFilterPresetSelection"/>.
+        /// </summary>
+        private bool GameMeetsCurrentFilters(Game game, FilterPresetSelection selection, out bool evaluationFailed)
+        {
+            return EvaluateExportEligibility(selection.Included, selection.Excluded, presetId =>
             {
                 var filterPreset = PlayniteApi.Database.FilterPresets
                     .FirstOrDefault(fp => fp.Id == presetId);
@@ -742,7 +835,7 @@ namespace ApolloSync
         /// failed write cannot leave the in-memory store disowning entries that are still in
         /// apps.json. Same ordering rule as ExportGamesWithFeedback.
         /// </summary>
-        private List<Guid> RemoveFilteredOutGames(JObject config, HashSet<Guid> pinnedGameIds, IList<Guid> selectedPresetIds)
+        private List<Guid> RemoveFilteredOutGames(JObject config, HashSet<Guid> pinnedGameIds, FilterPresetSelection selection)
         {
             var pinned = pinnedGameIds ?? new HashSet<Guid>(_settings.Settings.PinnedGameIds);
             var gamesToRemove = new List<KeyValuePair<Guid, Guid>>();
@@ -761,7 +854,7 @@ namespace ApolloSync
                     var filterEvaluationFailed = false;
                     if (game != null)
                     {
-                        meetsFilters = GameMeetsCurrentFilters(game, selectedPresetIds, out filterEvaluationFailed);
+                        meetsFilters = GameMeetsCurrentFilters(game, selection, out filterEvaluationFailed);
                     }
 
                     if (!ShouldRemoveManagedGame(game != null, pinned.Contains(gameId), meetsFilters, filterEvaluationFailed))
@@ -877,13 +970,13 @@ namespace ApolloSync
 
             // One snapshot for the whole sync: both phases must agree on which presets were
             // selected, and the live list can change under us while the settings view is open.
-            var selectedPresetIds = SnapshotSelectedPresetIds();
+            var selection = SnapshotFilterPresetSelection();
 
             // Deliberately no early return when nothing matches. Unchecking a preset is how the
             // user says "stop exporting these", and it is the removal phase below — not the
             // add/update phase — that carries it out. Returning here left the games in apps.json
             // until something else happened to match again.
-            var filteredGames = GetFilteredGames(selectedPresetIds);
+            var filteredGames = GetFilteredGames(selection);
             logger.Info($"Found {filteredGames.Count} games matching filter presets to sync");
 
             var localSuccess = 0;
@@ -926,7 +1019,7 @@ namespace ApolloSync
 
             // Phase 1: Remove managed games that no longer meet filters (unless pinned). The
             // store entries are dropped further down, once the write has actually landed.
-            var gamesToUnmanage = RemoveFilteredOutGames(config, pinnedSnapshot, selectedPresetIds);
+            var gamesToUnmanage = RemoveFilteredOutGames(config, pinnedSnapshot, selection);
             localRemoved = gamesToUnmanage.Count;
             logger.Info($"Removed {localRemoved} games that no longer meet filters");
 

--- a/Localization/cs_CZ.xaml
+++ b/Localization/cs_CZ.xaml
@@ -50,6 +50,8 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Předvolba filtru</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Použít předvolbu filtru Playnite</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Pokud je povoleno, bude místo jednotlivých filtrů níže použita vybraná předvolba filtru. Předvolby filtrů vytvořte v hlavním zobrazení knihovny Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ExcludedFilterPresets">Vyloučené předvolby filtrů</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ExcludedFilterPresets_Help">Hry odpovídající jakékoli vyloučené předvolbě se neexportují, i když odpovídají zahrnuté předvolbě. Připnuté hry se při shodě s vyloučenou předvolbou automaticky neodeberou.</sys:String>
 
     <!-- Manage Games Tab -->
     <sys:String x:Key="LOC_ApolloSync_Settings_ManageGames">Spravovat exportované hry</sys:String>

--- a/Localization/de_DE.xaml
+++ b/Localization/de_DE.xaml
@@ -50,6 +50,8 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Filtervoreinstellung</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Playnite-Filtervoreinstellung verwenden</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Wenn aktiviert, wird die ausgewählte Filtervoreinstellung anstelle der einzelnen Filter unten verwendet. Erstellen Sie Filtervoreinstellungen in der Hauptbibliotheksansicht von Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ExcludedFilterPresets">Ausgeschlossene Filtervoreinstellungen</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ExcludedFilterPresets_Help">Spiele, die einer ausgeschlossenen Filtervoreinstellung entsprechen, werden nicht exportiert, auch wenn sie einer eingeschlossenen Voreinstellung entsprechen. Angeheftete Spiele werden bei Übereinstimmung mit einer ausgeschlossenen Voreinstellung nicht automatisch entfernt.</sys:String>
 
     <!-- Manage Games Tab -->
     <sys:String x:Key="LOC_ApolloSync_Settings_ManageGames">Exportierte Spiele verwalten</sys:String>

--- a/Localization/en_US.xaml
+++ b/Localization/en_US.xaml
@@ -50,6 +50,8 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Filter Preset</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Use Playnite Filter Preset</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">When enabled, the selected filter preset will be used instead of the individual filters below. Create filter presets in Playnite's main library view.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ExcludedFilterPresets">Excluded Filter Presets</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ExcludedFilterPresets_Help">Games matching any excluded preset are not exported, even if they match an included preset. Pinned games are not auto-removed when they match an excluded preset.</sys:String>
 
     <!-- Manage Games Tab -->
     <sys:String x:Key="LOC_ApolloSync_Settings_ManageGames">Manage Exported Games</sys:String>

--- a/Localization/es_ES.xaml
+++ b/Localization/es_ES.xaml
@@ -50,6 +50,8 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Preajuste de filtro</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Usar preajuste de filtro de Playnite</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Cuando está activado, se usará el preajuste de filtro seleccionado en lugar de los filtros individuales de abajo. Crea preajustes de filtro en la vista principal de la biblioteca de Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ExcludedFilterPresets">Preajustes de filtro excluidos</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ExcludedFilterPresets_Help">Los juegos que coincidan con cualquier preajuste excluido no se exportan, aunque coincidan con un preajuste incluido. Los juegos fijados no se eliminan automáticamente cuando coinciden con un preajuste excluido.</sys:String>
 
     <!-- Manage Games Tab -->
     <sys:String x:Key="LOC_ApolloSync_Settings_ManageGames">Administrar juegos exportados</sys:String>

--- a/Localization/fr_FR.xaml
+++ b/Localization/fr_FR.xaml
@@ -50,6 +50,8 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Préréglage de filtre</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Utiliser un préréglage de filtre Playnite</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Lorsque activé, le préréglage de filtre sélectionné sera utilisé à la place des filtres individuels ci-dessous. Créez des préréglages de filtre dans la vue principale de la bibliothèque Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ExcludedFilterPresets">Préréglages de filtre exclus</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ExcludedFilterPresets_Help">Les jeux correspondant à un préréglage exclu ne sont pas exportés, même s'ils correspondent à un préréglage inclus. Les jeux épinglés ne sont pas automatiquement supprimés lorsqu'ils correspondent à un préréglage exclu.</sys:String>
 
     <!-- Manage Games Tab -->
     <sys:String x:Key="LOC_ApolloSync_Settings_ManageGames">Gérer les jeux exportés</sys:String>

--- a/Localization/it_IT.xaml
+++ b/Localization/it_IT.xaml
@@ -50,6 +50,8 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Preset filtro</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Usa preset filtro di Playnite</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Quando attivato, verrà utilizzato il preset filtro selezionato al posto dei filtri individuali sottostanti. Crea i preset filtro nella vista principale della libreria di Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ExcludedFilterPresets">Preset filtro esclusi</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ExcludedFilterPresets_Help">I giochi che corrispondono a un preset escluso non vengono esportati, anche se corrispondono a un preset incluso. I giochi fissati non vengono rimossi automaticamente quando corrispondono a un preset escluso.</sys:String>
 
     <!-- Manage Games Tab -->
     <sys:String x:Key="LOC_ApolloSync_Settings_ManageGames">Gestisci giochi esportati</sys:String>

--- a/Localization/ja_JP.xaml
+++ b/Localization/ja_JP.xaml
@@ -50,6 +50,8 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">フィルタープリセット</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Playniteのフィルタープリセットを使用</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">有効にすると、以下の個別フィルターの代わりに選択したフィルタープリセットが使用されます。フィルタープリセットはPlayniteのメインライブラリ画面で作成できます。</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ExcludedFilterPresets">除外フィルタープリセット</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ExcludedFilterPresets_Help">除外プリセットに一致するゲームは、含めるプリセットに一致していてもエクスポートされません。ピン留めされたゲームは、除外プリセットに一致しても自動削除されません。</sys:String>
 
     <!-- Manage Games Tab -->
     <sys:String x:Key="LOC_ApolloSync_Settings_ManageGames">エクスポート済みゲームの管理</sys:String>

--- a/Localization/ko_KR.xaml
+++ b/Localization/ko_KR.xaml
@@ -50,6 +50,8 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">필터 프리셋</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Playnite 필터 프리셋 사용</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">활성화하면 아래의 개별 필터 대신 선택한 필터 프리셋이 사용됩니다. 필터 프리셋은 Playnite의 메인 라이브러리 화면에서 만들 수 있습니다.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ExcludedFilterPresets">제외 필터 프리셋</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ExcludedFilterPresets_Help">제외된 프리셋에 일치하는 게임은 포함된 프리셋에 일치하더라도 내보내지지 않습니다. 고정된 게임은 제외 프리셋에 일치해도 자동으로 삭제되지 않습니다.</sys:String>
 
     <!-- Manage Games Tab -->
     <sys:String x:Key="LOC_ApolloSync_Settings_ManageGames">내보낸 게임 관리</sys:String>

--- a/Localization/nl_NL.xaml
+++ b/Localization/nl_NL.xaml
@@ -50,6 +50,8 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Filtervoorinstelling</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Playnite-filtervoorinstelling gebruiken</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Wanneer ingeschakeld, wordt de geselecteerde filtervoorinstelling gebruikt in plaats van de afzonderlijke filters hieronder. Maak filtervoorinstellingen aan in de hoofdbibliotheekweergave van Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ExcludedFilterPresets">Uitgesloten filtervoorinstellingen</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ExcludedFilterPresets_Help">Games die overeenkomen met een uitgesloten voorinstelling worden niet geëxporteerd, ook niet als ze overeenkomen met een inbegrepen voorinstelling. Vastgepinde games worden niet automatisch verwijderd wanneer ze overeenkomen met een uitgesloten voorinstelling.</sys:String>
 
     <!-- Manage Games Tab -->
     <sys:String x:Key="LOC_ApolloSync_Settings_ManageGames">Geëxporteerde games beheren</sys:String>

--- a/Localization/pl_PL.xaml
+++ b/Localization/pl_PL.xaml
@@ -50,6 +50,8 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Szablon filtrów</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Użyj szablonu filtrów Playnite</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Po włączeniu wybrany szablon filtrów zostanie użyty zamiast poszczególnych filtrów poniżej. Twórz szablony filtrów w głównym widoku biblioteki Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ExcludedFilterPresets">Wykluczone szablony filtrów</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ExcludedFilterPresets_Help">Gry pasujące do dowolnego wykluczonego szablonu nie są eksportowane, nawet jeśli pasują do szablonu uwzględnionego. Przypięte gry nie są automatycznie usuwane, gdy pasują do wykluczonego szablonu.</sys:String>
 
     <!-- Manage Games Tab -->
     <sys:String x:Key="LOC_ApolloSync_Settings_ManageGames">Zarządzaj wyeksportowanymi grami</sys:String>

--- a/Localization/pt_BR.xaml
+++ b/Localization/pt_BR.xaml
@@ -50,6 +50,8 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Predefinição de filtro</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Usar predefinição de filtro do Playnite</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Quando ativado, a predefinição de filtro selecionada será usada no lugar dos filtros individuais abaixo. Crie predefinições de filtro na visualização principal da biblioteca do Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ExcludedFilterPresets">Predefinições de filtro excluídas</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ExcludedFilterPresets_Help">Jogos que correspondem a qualquer predefinição excluída não são exportados, mesmo que correspondam a uma predefinição incluída. Jogos fixados não são removidos automaticamente quando correspondem a uma predefinição excluída.</sys:String>
 
     <!-- Manage Games Tab -->
     <sys:String x:Key="LOC_ApolloSync_Settings_ManageGames">Gerenciar jogos exportados</sys:String>

--- a/Localization/pt_PT.xaml
+++ b/Localization/pt_PT.xaml
@@ -50,6 +50,8 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Predefinição de filtro</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Usar predefinição de filtro do Playnite</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Quando ativado, a predefinição de filtro selecionada será utilizada em vez dos filtros individuais abaixo. Crie predefinições de filtro na vista principal da biblioteca do Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ExcludedFilterPresets">Predefinições de filtro excluídas</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ExcludedFilterPresets_Help">Os jogos que correspondam a qualquer predefinição excluída não são exportados, mesmo que correspondam a uma predefinição incluída. Os jogos fixados não são automaticamente removidos quando correspondem a uma predefinição excluída.</sys:String>
 
     <!-- Manage Games Tab -->
     <sys:String x:Key="LOC_ApolloSync_Settings_ManageGames">Gerir jogos exportados</sys:String>

--- a/Localization/ro_RO.xaml
+++ b/Localization/ro_RO.xaml
@@ -50,6 +50,8 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Presetare filtru</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Folosește presetarea de filtru Playnite</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Când este activat, presetarea de filtru selectată va fi folosită în locul filtrelor individuale de mai jos. Creează presetări de filtru în vizualizarea principală a bibliotecii Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ExcludedFilterPresets">Presetări filtru excluse</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ExcludedFilterPresets_Help">Jocurile care se potrivesc cu orice presetare exclusă nu sunt exportate, chiar dacă se potrivesc cu o presetare inclusă. Jocurile fixate nu sunt eliminate automat când se potrivesc cu o presetare exclusă.</sys:String>
 
     <!-- Manage Games Tab -->
     <sys:String x:Key="LOC_ApolloSync_Settings_ManageGames">Gestionează jocurile exportate</sys:String>

--- a/Localization/ru_RU.xaml
+++ b/Localization/ru_RU.xaml
@@ -50,6 +50,8 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Предустановка фильтра</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Использовать предустановку фильтра Playnite</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Если включено, вместо отдельных фильтров ниже будет использоваться выбранная предустановка фильтра. Создавайте предустановки фильтров в главном представлении библиотеки Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ExcludedFilterPresets">Исключённые предустановки фильтров</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ExcludedFilterPresets_Help">Игры, соответствующие любой исключённой предустановке, не экспортируются, даже если они соответствуют включённой предустановке. Закреплённые игры не удаляются автоматически при соответствии исключённой предустановке.</sys:String>
 
     <!-- Manage Games Tab -->
     <sys:String x:Key="LOC_ApolloSync_Settings_ManageGames">Управление экспортированными играми</sys:String>

--- a/Localization/sv_SE.xaml
+++ b/Localization/sv_SE.xaml
@@ -50,6 +50,8 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Filterförinställning</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Använd Playnite-filterförinställning</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">När aktiverat används den valda filterförinställningen istället för de enskilda filtren nedan. Skapa filterförinställningar i Playnites huvudbiblioteksvy.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ExcludedFilterPresets">Uteslutna filterförinställningar</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ExcludedFilterPresets_Help">Spel som matchar en utesluten förinställning exporteras inte, även om de matchar en inkluderad förinställning. Fästa spel tas inte bort automatiskt när de matchar en utesluten förinställning.</sys:String>
 
     <!-- Manage Games Tab -->
     <sys:String x:Key="LOC_ApolloSync_Settings_ManageGames">Hantera exporterade spel</sys:String>

--- a/Localization/tr_TR.xaml
+++ b/Localization/tr_TR.xaml
@@ -50,6 +50,8 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Filtre Ön Ayarı</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Playnite Filtre Ön Ayarını Kullan</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Etkinleştirildiğinde, aşağıdaki ayrı filtreler yerine seçilen filtre ön ayarı kullanılır. Filtre ön ayarlarını Playnite'ın ana kütüphane görünümünde oluşturabilirsiniz.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ExcludedFilterPresets">Hariç Tutulan Filtre Ön Ayarları</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ExcludedFilterPresets_Help">Hariç tutulan herhangi bir ön ayarla eşleşen oyunlar, dahil edilen bir ön ayarla eşleşseler bile aktarılmaz. Sabitlenen oyunlar, hariç tutulan bir ön ayarla eşleştiklerinde otomatik olarak silinmez.</sys:String>
 
     <!-- Manage Games Tab -->
     <sys:String x:Key="LOC_ApolloSync_Settings_ManageGames">Aktarılan Oyunları Yönet</sys:String>

--- a/Localization/uk_UA.xaml
+++ b/Localization/uk_UA.xaml
@@ -50,6 +50,8 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">Набір фільтрів</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">Використовувати набір фільтрів Playnite</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">Якщо увімкнено, замість окремих фільтрів нижче буде використовуватися вибраний набір фільтрів. Створюйте набори фільтрів у головному вигляді бібліотеки Playnite.</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ExcludedFilterPresets">Виключені набори фільтрів</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ExcludedFilterPresets_Help">Ігри, що відповідають будь-якому виключеному набору, не експортуються, навіть якщо вони відповідають включеному набору. Закріплені ігри не видаляються автоматично при відповідності виключеному набору.</sys:String>
 
     <!-- Manage Games Tab -->
     <sys:String x:Key="LOC_ApolloSync_Settings_ManageGames">Керування експортованими іграми</sys:String>

--- a/Localization/zh_CN.xaml
+++ b/Localization/zh_CN.xaml
@@ -50,6 +50,8 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">筛选预设</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">使用Playnite筛选预设</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">启用后，将使用所选的筛选预设替代下方的各项筛选条件。可在Playnite的主库视图中创建筛选预设。</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ExcludedFilterPresets">排除的筛选预设</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ExcludedFilterPresets_Help">匹配任何排除预设的游戏不会被导出，即使它们也匹配包含的预设。固定的游戏在匹配排除预设时不会被自动移除。</sys:String>
 
     <!-- Manage Games Tab -->
     <sys:String x:Key="LOC_ApolloSync_Settings_ManageGames">管理已导出的游戏</sys:String>

--- a/Localization/zh_TW.xaml
+++ b/Localization/zh_TW.xaml
@@ -50,6 +50,8 @@
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset">篩選預設</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_UseFilterPreset">使用Playnite篩選預設</sys:String>
     <sys:String x:Key="LOC_ApolloSync_Settings_FilterPreset_Help">啟用後，將使用所選的篩選預設取代下方的各項篩選條件。可在Playnite的主媒體庫檢視中建立篩選預設。</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ExcludedFilterPresets">排除的篩選預設</sys:String>
+    <sys:String x:Key="LOC_ApolloSync_Settings_ExcludedFilterPresets_Help">符合任何排除預設的遊戲不會被匯出，即使它們也符合包含的預設。釘選的遊戲在符合排除預設時不會被自動移除。</sys:String>
 
     <!-- Manage Games Tab -->
     <sys:String x:Key="LOC_ApolloSync_Settings_ManageGames">管理已匯出的遊戲</sys:String>

--- a/Settings/ApolloSyncSettings.cs
+++ b/Settings/ApolloSyncSettings.cs
@@ -61,6 +61,13 @@ namespace ApolloSync
             set => SetValue(ref _includedFilterPresetIds, value);
         }
 
+        private List<Guid> _excludedFilterPresetIds = new List<Guid>();
+        public List<Guid> ExcludedFilterPresetIds
+        {
+            get => _excludedFilterPresetIds;
+            set => SetValue(ref _excludedFilterPresetIds, value);
+        }
+
         private bool _manageCoverImages = true;
         /// <summary>
         /// When false the plugin never writes or clears the "image-path" field, leaving whatever

--- a/Settings/ApolloSyncSettingsView.xaml.cs
+++ b/Settings/ApolloSyncSettingsView.xaml.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Data;
 using System.Windows.Media;
 using Microsoft.Win32;
@@ -289,7 +290,7 @@ namespace ApolloSync
             };
 
             var filterPresetScrollViewer = new ScrollViewer { MaxHeight = 150, VerticalScrollBarVisibility = ScrollBarVisibility.Auto };
-            var filterPresetPanel = new StackPanel { Name = "FilterPresetsPanel" };
+            var filterPresetPanel = new UniformGrid { Name = "FilterPresetsPanel", Columns = 3 };
             filterPresetScrollViewer.Content = filterPresetPanel;
             filterPresetBorder.Child = filterPresetScrollViewer;
             filterPresetContentPanel.Children.Add(filterPresetBorder);
@@ -339,7 +340,7 @@ namespace ApolloSync
             };
 
             var excludedFilterPresetScrollViewer = new ScrollViewer { MaxHeight = 150, VerticalScrollBarVisibility = ScrollBarVisibility.Auto };
-            var excludedFilterPresetPanel = new StackPanel { Name = "ExcludedFilterPresetsPanel" };
+            var excludedFilterPresetPanel = new UniformGrid { Name = "ExcludedFilterPresetsPanel", Columns = 3 };
             excludedFilterPresetScrollViewer.Content = excludedFilterPresetPanel;
             excludedFilterPresetBorder.Child = excludedFilterPresetScrollViewer;
             excludedFilterPresetContentPanel.Children.Add(excludedFilterPresetBorder);
@@ -473,7 +474,7 @@ namespace ApolloSync
                 {
                     vm.Settings.IncludedFilterPresetIds.Add(filterPreset.Id);
                 }
-                UpdateFilterPresetCheckboxes(FindChild<StackPanel>(this, "FilterPresetsPanel"));
+                UpdateFilterPresetCheckboxes(FindChild<UniformGrid>(this, "FilterPresetsPanel"));
             }
         }
 
@@ -482,7 +483,7 @@ namespace ApolloSync
             if (DataContext is ApolloSyncSettingsViewModel vm)
             {
                 vm.Settings.IncludedFilterPresetIds.Clear();
-                UpdateFilterPresetCheckboxes(FindChild<StackPanel>(this, "FilterPresetsPanel"));
+                UpdateFilterPresetCheckboxes(FindChild<UniformGrid>(this, "FilterPresetsPanel"));
             }
         }
 
@@ -558,7 +559,7 @@ namespace ApolloSync
                 {
                     vm.Settings.ExcludedFilterPresetIds.Add(filterPreset.Id);
                 }
-                UpdateExcludedFilterPresetCheckboxes(FindChild<StackPanel>(this, "ExcludedFilterPresetsPanel"));
+                UpdateExcludedFilterPresetCheckboxes(FindChild<UniformGrid>(this, "ExcludedFilterPresetsPanel"));
             }
         }
 
@@ -572,7 +573,7 @@ namespace ApolloSync
                 }
 
                 vm.Settings.ExcludedFilterPresetIds.Clear();
-                UpdateExcludedFilterPresetCheckboxes(FindChild<StackPanel>(this, "ExcludedFilterPresetsPanel"));
+                UpdateExcludedFilterPresetCheckboxes(FindChild<UniformGrid>(this, "ExcludedFilterPresetsPanel"));
             }
         }
 

--- a/Settings/ApolloSyncSettingsView.xaml.cs
+++ b/Settings/ApolloSyncSettingsView.xaml.cs
@@ -245,8 +245,15 @@ namespace ApolloSync
             return stack;
         }
 
-        private StackPanel BuildFiltersTab()
+        private FrameworkElement BuildFiltersTab()
         {
+            // Outer scroll so both expanders (help + list + buttons) remain reachable when the
+            // settings window is short — StackPanel alone was clipping the excluded section.
+            var outerScroll = new ScrollViewer
+            {
+                VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+                HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled
+            };
             var stack = new StackPanel { Margin = new Thickness(8) };
 
             // Filter presets are the only filter mechanism. Platform, label, completion status
@@ -264,12 +271,21 @@ namespace ApolloSync
 
             var filterPresetContentPanel = new StackPanel();
 
+            filterPresetContentPanel.Children.Add(new TextBlock
+            {
+                Text = "Select one or more filter presets. Games that match ANY selected preset will be eligible for export (OR logic). Create filter presets in Playnite's main library view first.",
+                TextWrapping = TextWrapping.Wrap,
+                Margin = new Thickness(0, 0, 0, 4),
+                Foreground = System.Windows.Media.Brushes.Gray,
+                FontStyle = FontStyles.Italic
+            });
+
             // Create filter preset selection table
             var filterPresetBorder = new Border
             {
                 BorderBrush = System.Windows.Media.Brushes.Gray,
                 BorderThickness = new Thickness(1),
-                Margin = new Thickness(0, 4, 0, 0)
+                Margin = new Thickness(0, 0, 0, 0)
             };
 
             var filterPresetScrollViewer = new ScrollViewer { MaxHeight = 150, VerticalScrollBarVisibility = ScrollBarVisibility.Auto };
@@ -288,33 +304,75 @@ namespace ApolloSync
             filterPresetButtonPanel.Children.Add(clearAllFilterPresetBtn);
             filterPresetContentPanel.Children.Add(filterPresetButtonPanel);
 
-            // Help text
-            filterPresetContentPanel.Children.Add(new TextBlock
-            {
-                Text = "Select one or more filter presets. Games that match ANY selected preset will be eligible for export (OR logic). Create filter presets in Playnite's main library view first.",
-                TextWrapping = TextWrapping.Wrap,
-                Margin = new Thickness(0, 4, 0, 0),
-                Foreground = System.Windows.Media.Brushes.Gray,
-                FontStyle = FontStyles.Italic
-            });
-
-            // Populate filter presets when DataContext is available
-            if (DataContext is ApolloSyncSettingsViewModel vm4)
+            if (DataContext is ApolloSyncSettingsViewModel)
             {
                 UpdateFilterPresetCheckboxes(filterPresetPanel);
             }
-            DataContextChanged += (s, e) =>
-            {
-                if (DataContext is ApolloSyncSettingsViewModel viewModel4)
-                {
-                    UpdateFilterPresetCheckboxes(filterPresetPanel);
-                }
-            };
 
             filterPresetExpander.Content = filterPresetContentPanel;
             stack.Children.Add(filterPresetExpander);
 
-            return stack;
+            // Excluded Filter Presets (collapsible)
+            var excludedFilterPresetExpander = new Expander
+            {
+                Header = ResourceProvider.GetString("LOC_ApolloSync_Settings_ExcludedFilterPresets"),
+                IsExpanded = true,
+                Margin = new Thickness(0, 0, 0, 8)
+            };
+
+            var excludedFilterPresetContentPanel = new StackPanel();
+
+            excludedFilterPresetContentPanel.Children.Add(new TextBlock
+            {
+                Text = ResourceProvider.GetString("LOC_ApolloSync_Settings_ExcludedFilterPresets_Help"),
+                TextWrapping = TextWrapping.Wrap,
+                Margin = new Thickness(0, 0, 0, 4),
+                Foreground = System.Windows.Media.Brushes.Gray,
+                FontStyle = FontStyles.Italic
+            });
+
+            var excludedFilterPresetBorder = new Border
+            {
+                BorderBrush = System.Windows.Media.Brushes.Gray,
+                BorderThickness = new Thickness(1),
+                Margin = new Thickness(0, 0, 0, 0)
+            };
+
+            var excludedFilterPresetScrollViewer = new ScrollViewer { MaxHeight = 150, VerticalScrollBarVisibility = ScrollBarVisibility.Auto };
+            var excludedFilterPresetPanel = new StackPanel { Name = "ExcludedFilterPresetsPanel" };
+            excludedFilterPresetScrollViewer.Content = excludedFilterPresetPanel;
+            excludedFilterPresetBorder.Child = excludedFilterPresetScrollViewer;
+            excludedFilterPresetContentPanel.Children.Add(excludedFilterPresetBorder);
+
+            var excludedFilterPresetButtonPanel = new StackPanel { Orientation = Orientation.Horizontal, Margin = new Thickness(0, 4, 0, 0) };
+            var selectAllExcludedFilterPresetBtn = new Button { Content = "Select All", Width = 80, Margin = new Thickness(0, 0, 4, 0) };
+            var clearAllExcludedFilterPresetBtn = new Button { Content = "Clear All", Width = 80 };
+            selectAllExcludedFilterPresetBtn.Click += SelectAllExcludedFilterPresets_Click;
+            clearAllExcludedFilterPresetBtn.Click += ClearAllExcludedFilterPresets_Click;
+            excludedFilterPresetButtonPanel.Children.Add(selectAllExcludedFilterPresetBtn);
+            excludedFilterPresetButtonPanel.Children.Add(clearAllExcludedFilterPresetBtn);
+            excludedFilterPresetContentPanel.Children.Add(excludedFilterPresetButtonPanel);
+
+            
+            // Populate filter presets when DataContext is available
+            if (DataContext is ApolloSyncSettingsViewModel)
+            {
+                UpdateExcludedFilterPresetCheckboxes(excludedFilterPresetPanel);
+            }
+            DataContextChanged += (s, e) =>
+            {
+                if (DataContext is ApolloSyncSettingsViewModel)
+                {
+                    UpdateFilterPresetCheckboxes(filterPresetPanel);
+                    UpdateExcludedFilterPresetCheckboxes(excludedFilterPresetPanel);
+                }
+            };
+
+            excludedFilterPresetExpander.Content = excludedFilterPresetContentPanel;
+            stack.Children.Add(excludedFilterPresetExpander);
+
+            outerScroll.Content = stack;
+            return outerScroll;
         }
 
         private StackPanel BuildManageGamesTab()
@@ -368,7 +426,7 @@ namespace ApolloSync
 
         #region Filter Preset Methods
 
-        private void UpdateFilterPresetCheckboxes(StackPanel filterPresetPanel)
+        private void UpdateFilterPresetCheckboxes(Panel filterPresetPanel)
         {
             filterPresetPanel.Children.Clear();
 
@@ -381,6 +439,11 @@ namespace ApolloSync
 
                 if (vm.AvailableFilterPresets != null)
                 {
+                    if (vm.Settings.IncludedFilterPresetIds == null)
+                    {
+                        vm.Settings.IncludedFilterPresetIds = new List<Guid>();
+                    }
+
                     foreach (var filterPreset in vm.AvailableFilterPresets)
                     {
                         var checkbox = new CheckBox
@@ -427,6 +490,11 @@ namespace ApolloSync
         {
             if (DataContext is ApolloSyncSettingsViewModel vm)
             {
+                if (vm.Settings.IncludedFilterPresetIds == null)
+                {
+                    vm.Settings.IncludedFilterPresetIds = new List<Guid>();
+                }
+
                 if (isChecked && !vm.Settings.IncludedFilterPresetIds.Contains(presetId))
                 {
                     vm.Settings.IncludedFilterPresetIds.Add(presetId);
@@ -434,6 +502,96 @@ namespace ApolloSync
                 else if (!isChecked && vm.Settings.IncludedFilterPresetIds.Contains(presetId))
                 {
                     vm.Settings.IncludedFilterPresetIds.Remove(presetId);
+                }
+            }
+        }
+
+        private void UpdateExcludedFilterPresetCheckboxes(Panel excludedFilterPresetPanel)
+        {
+            excludedFilterPresetPanel.Children.Clear();
+
+            if (DataContext is ApolloSyncSettingsViewModel vm)
+            {
+                if (vm.AvailableFilterPresets == null || vm.AvailableFilterPresets.Count == 0)
+                {
+                    vm.RefreshFilterPresets();
+                }
+
+                if (vm.Settings.ExcludedFilterPresetIds == null)
+                {
+                    vm.Settings.ExcludedFilterPresetIds = new List<Guid>();
+                }
+
+                if (vm.AvailableFilterPresets != null)
+                {
+                    foreach (var filterPreset in vm.AvailableFilterPresets)
+                    {
+                        var checkbox = new CheckBox
+                        {
+                            Content = filterPreset.Name,
+                            Tag = filterPreset.Id,
+                            Margin = new Thickness(0, 2, 0, 2)
+                        };
+
+                        checkbox.IsChecked = vm.Settings.ExcludedFilterPresetIds.Contains(filterPreset.Id);
+
+                        checkbox.Checked += (s, e) => OnExcludedFilterPresetCheckboxChanged(filterPreset.Id, true);
+                        checkbox.Unchecked += (s, e) => OnExcludedFilterPresetCheckboxChanged(filterPreset.Id, false);
+
+                        excludedFilterPresetPanel.Children.Add(checkbox);
+                    }
+                }
+            }
+        }
+
+        private void SelectAllExcludedFilterPresets_Click(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is ApolloSyncSettingsViewModel vm && vm.AvailableFilterPresets != null)
+            {
+                if (vm.Settings.ExcludedFilterPresetIds == null)
+                {
+                    vm.Settings.ExcludedFilterPresetIds = new List<Guid>();
+                }
+
+                vm.Settings.ExcludedFilterPresetIds.Clear();
+                foreach (var filterPreset in vm.AvailableFilterPresets)
+                {
+                    vm.Settings.ExcludedFilterPresetIds.Add(filterPreset.Id);
+                }
+                UpdateExcludedFilterPresetCheckboxes(FindChild<StackPanel>(this, "ExcludedFilterPresetsPanel"));
+            }
+        }
+
+        private void ClearAllExcludedFilterPresets_Click(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is ApolloSyncSettingsViewModel vm)
+            {
+                if (vm.Settings.ExcludedFilterPresetIds == null)
+                {
+                    vm.Settings.ExcludedFilterPresetIds = new List<Guid>();
+                }
+
+                vm.Settings.ExcludedFilterPresetIds.Clear();
+                UpdateExcludedFilterPresetCheckboxes(FindChild<StackPanel>(this, "ExcludedFilterPresetsPanel"));
+            }
+        }
+
+        private void OnExcludedFilterPresetCheckboxChanged(Guid presetId, bool isChecked)
+        {
+            if (DataContext is ApolloSyncSettingsViewModel vm)
+            {
+                if (vm.Settings.ExcludedFilterPresetIds == null)
+                {
+                    vm.Settings.ExcludedFilterPresetIds = new List<Guid>();
+                }
+
+                if (isChecked && !vm.Settings.ExcludedFilterPresetIds.Contains(presetId))
+                {
+                    vm.Settings.ExcludedFilterPresetIds.Add(presetId);
+                }
+                else if (!isChecked && vm.Settings.ExcludedFilterPresetIds.Contains(presetId))
+                {
+                    vm.Settings.ExcludedFilterPresetIds.Remove(presetId);
                 }
             }
         }

--- a/Tests/AppsJsonManagementTests.cs
+++ b/Tests/AppsJsonManagementTests.cs
@@ -296,6 +296,204 @@ namespace ApolloSync.Tests
                 "Evaluation must short-circuit on the first match");
         }
 
+        // ── EvaluateExportEligibility ─────────────────────────────────────────────
+        // include ∪ − exclude ∪, with dangling-exclude safety. Exclusion beats inclusion;
+        // pin/removal rules stay in ShouldRemoveManagedGame.
+
+        [TestMethod]
+        public void EvaluateExportEligibility_IncludeMatchWithNoExcludesIsEligible()
+        {
+            bool failed;
+            var eligible = global::ApolloSync.ApolloSync.EvaluateExportEligibility(
+                new List<Guid> { Guid.NewGuid() },
+                new List<Guid>(),
+                id => true,
+                out failed);
+
+            Assert.IsTrue(eligible);
+            Assert.IsFalse(failed);
+        }
+
+        [TestMethod]
+        public void EvaluateExportEligibility_IncludeMatchWithNullExcludesIsEligible()
+        {
+            bool failed;
+            var eligible = global::ApolloSync.ApolloSync.EvaluateExportEligibility(
+                new List<Guid> { Guid.NewGuid() },
+                null,
+                id => true,
+                out failed);
+
+            Assert.IsTrue(eligible);
+            Assert.IsFalse(failed);
+        }
+
+        [TestMethod]
+        public void EvaluateExportEligibility_IncludeAndExcludeMatchIsNotEligible()
+        {
+            var includeId = Guid.NewGuid();
+            var excludeId = Guid.NewGuid();
+
+            bool failed;
+            var eligible = global::ApolloSync.ApolloSync.EvaluateExportEligibility(
+                new List<Guid> { includeId },
+                new List<Guid> { excludeId },
+                id => true,
+                out failed);
+
+            Assert.IsFalse(eligible);
+            Assert.IsFalse(failed);
+            Assert.IsTrue(global::ApolloSync.ApolloSync.ShouldRemoveManagedGame(
+                gameExistsInLibrary: true, isPinned: false, meetsFilters: eligible, filterEvaluationFailed: failed));
+        }
+
+        [TestMethod]
+        public void EvaluateExportEligibility_EmptyIncludesIsNotEligibleAndPrunes()
+        {
+            bool failed;
+            var eligible = global::ApolloSync.ApolloSync.EvaluateExportEligibility(
+                new List<Guid>(),
+                new List<Guid> { Guid.NewGuid() },
+                id => true,
+                out failed);
+
+            Assert.IsFalse(eligible);
+            Assert.IsFalse(failed);
+            Assert.IsTrue(global::ApolloSync.ApolloSync.ShouldRemoveManagedGame(
+                gameExistsInLibrary: true, isPinned: false, meetsFilters: eligible, filterEvaluationFailed: failed));
+        }
+
+        [TestMethod]
+        public void EvaluateExportEligibility_NullIncludesIsNotEligibleAndPrunes()
+        {
+            bool failed;
+            var eligible = global::ApolloSync.ApolloSync.EvaluateExportEligibility(
+                null,
+                new List<Guid> { Guid.NewGuid() },
+                id => true,
+                out failed);
+
+            Assert.IsFalse(eligible);
+            Assert.IsFalse(failed);
+        }
+
+        [TestMethod]
+        public void EvaluateExportEligibility_IncludeMatchWithDanglingExcludeBlocksRemoval()
+        {
+            // Ticket #30: a deleted exclusion preset must not silently re-export / treat as
+            // "excludes nothing".
+            var includeId = Guid.NewGuid();
+            var danglingExclude = Guid.NewGuid();
+
+            bool failed;
+            var eligible = global::ApolloSync.ApolloSync.EvaluateExportEligibility(
+                new List<Guid> { includeId },
+                new List<Guid> { danglingExclude },
+                id => id == includeId ? true : (bool?)null,
+                out failed);
+
+            Assert.IsFalse(eligible);
+            Assert.IsTrue(failed);
+            Assert.IsFalse(global::ApolloSync.ApolloSync.ShouldRemoveManagedGame(
+                gameExistsInLibrary: true, isPinned: false, meetsFilters: eligible, filterEvaluationFailed: failed));
+        }
+
+        [TestMethod]
+        public void EvaluateExportEligibility_IncludeMatchWithThrowingExcludeBlocksRemoval()
+        {
+            var includeId = Guid.NewGuid();
+            var throwingExclude = Guid.NewGuid();
+
+            bool failed;
+            var eligible = global::ApolloSync.ApolloSync.EvaluateExportEligibility(
+                new List<Guid> { includeId },
+                new List<Guid> { throwingExclude },
+                id =>
+                {
+                    if (id == throwingExclude)
+                    {
+                        throw new InvalidOperationException("exclude blew up");
+                    }
+                    return true;
+                },
+                out failed);
+
+            Assert.IsFalse(eligible);
+            Assert.IsTrue(failed);
+            Assert.IsFalse(global::ApolloSync.ApolloSync.ShouldRemoveManagedGame(
+                gameExistsInLibrary: true, isPinned: false, meetsFilters: eligible, filterEvaluationFailed: failed));
+        }
+
+        [TestMethod]
+        public void EvaluateExportEligibility_DefiniteExcludeWinsOverDanglingInclude()
+        {
+            var danglingInclude = Guid.NewGuid();
+            var excludeId = Guid.NewGuid();
+
+            bool failed;
+            var eligible = global::ApolloSync.ApolloSync.EvaluateExportEligibility(
+                new List<Guid> { danglingInclude },
+                new List<Guid> { excludeId },
+                id => id == excludeId ? true : (bool?)null,
+                out failed);
+
+            Assert.IsFalse(eligible);
+            Assert.IsFalse(failed, "A definite exclude must clear sibling include-failure flags");
+        }
+
+        [TestMethod]
+        public void EvaluateExportEligibility_DefiniteIncludeMissWithDanglingExcludeIsPrunable()
+        {
+            // Exclude cannot resurrect a game that definitely does not match includes.
+            var includeId = Guid.NewGuid();
+            var danglingExclude = Guid.NewGuid();
+
+            bool failed;
+            var eligible = global::ApolloSync.ApolloSync.EvaluateExportEligibility(
+                new List<Guid> { includeId },
+                new List<Guid> { danglingExclude },
+                id => id == includeId ? false : (bool?)null,
+                out failed);
+
+            Assert.IsFalse(eligible);
+            Assert.IsFalse(failed);
+            Assert.IsTrue(global::ApolloSync.ApolloSync.ShouldRemoveManagedGame(
+                gameExistsInLibrary: true, isPinned: false, meetsFilters: eligible, filterEvaluationFailed: failed));
+        }
+
+        [TestMethod]
+        public void EvaluateExportEligibility_IncludeMatchAfterThrowingSiblingIncludeIsEligible()
+        {
+            // Branch on included, not bare includeFailed — EvaluateFilterPresets can return
+            // matched=true with evaluationFailed=true after an earlier throw.
+            var throwingInclude = Guid.NewGuid();
+            var matchingInclude = Guid.NewGuid();
+
+            bool failed;
+            var eligible = global::ApolloSync.ApolloSync.EvaluateExportEligibility(
+                new List<Guid> { throwingInclude, matchingInclude },
+                new List<Guid>(),
+                id =>
+                {
+                    if (id == throwingInclude)
+                    {
+                        throw new InvalidOperationException("include blew up");
+                    }
+                    return id == matchingInclude;
+                },
+                out failed);
+
+            Assert.IsTrue(eligible);
+            Assert.IsFalse(failed);
+        }
+
+        [TestMethod]
+        public void EvaluateExportEligibility_PinnedGameThatMatchesExcludeIsKept()
+        {
+            Assert.IsFalse(global::ApolloSync.ApolloSync.ShouldRemoveManagedGame(
+                gameExistsInLibrary: true, isPinned: true, meetsFilters: false, filterEvaluationFailed: false));
+        }
+
         // ── ApplyRemovals ─────────────────────────────────────────────────────────
 
         [TestMethod]


### PR DESCRIPTION
This implements the ability to exclude games that match presets (#30), so players can eliminate things like "Mouse-only" or "Shooters" from syncing to the game list.

I also made the layout more dense; the single-column approach did not work well with both sets of checkboxes on screen.

<img width="3269" height="905" alt="image" src="https://github.com/user-attachments/assets/ed83d1cd-e66c-438c-a8b9-a5b0c5929656" />

I did notice something odd about Playnite behavior - `Alan Wake 2` wasn't showing up in my exclusion preset because while it matched `Shooter` Genre but not any of the selected tags (and I had both in the initial preset, but not the `Match all filters` checkbox). So to get this to work the way I intended, I had to make TWO presets and exclude them separately. Not sure whether or not that's technically a bug in Playnite, but I figured we want to behave however Playnite does, so...