### PR TITLE
Order apps.json by Playlist plugin rank order when that filter preset is synced

### DIFF
--- a/ApolloSync.cs
+++ b/ApolloSync.cs
@@ -1556,6 +1556,8 @@ namespace ApolloSync
         {
             try
             {
+                TryApplyPlaylistOrder(config);
+
                 var path = _settings.Settings.AppsJsonPath;
                 // Resolve to the concrete path ConfigService.Save will write to, so the
                 // elevation path below receives a valid local absolute path even when
@@ -1602,6 +1604,55 @@ namespace ApolloSync
                 // the failure. Swallowing it here made every caller's catch unreachable.
                 logger.Error(ex, $"Exception occurred while saving apps config");
                 throw;
+            }
+        }
+
+        /// <summary>
+        /// When the Playlist filter preset is included and the Playlist plugin is loaded,
+        /// reorders managed apps to match playlist.txt (with pinned hybrid ordering).
+        /// Preset check runs before plugin detection. Fail-soft on IO errors.
+        /// </summary>
+        private void TryApplyPlaylistOrder(JObject config)
+        {
+            if (config == null || _settings?.Settings == null || _managedStore == null)
+            {
+                return;
+            }
+
+            var includedCopy = _settings.Settings.IncludedFilterPresetIds != null
+                ? new List<Guid>(_settings.Settings.IncludedFilterPresetIds)
+                : new List<Guid>();
+
+            if (!PlaylistOrderService.IsPlaylistPresetIncluded(includedCopy, id =>
+            {
+                var preset = PlayniteApi.Database.FilterPresets.FirstOrDefault(fp => fp.Id == id);
+                return preset?.Name;
+            }))
+            {
+                return;
+            }
+
+            if (!PlaylistOrderService.IsPluginLoaded(PlayniteApi))
+            {
+                return;
+            }
+
+            var apps = config["apps"] as JArray;
+            if (apps == null)
+            {
+                return;
+            }
+
+            var playlistPath = PlaylistOrderService.GetPlaylistFilePath(PlayniteApi);
+            var playlistIds = PlaylistOrderService.TryReadOrderedGameIds(playlistPath);
+
+            var pinnedCopy = _settings.Settings.PinnedGameIds != null
+                ? new HashSet<Guid>(_settings.Settings.PinnedGameIds)
+                : new HashSet<Guid>();
+
+            if (PlaylistOrderService.ReorderApps(apps, playlistIds, _managedStore, pinnedCopy))
+            {
+                logger.Debug("Reordered apps.json entries for Playlist / pinned hybrid order");
             }
         }
 

--- a/Services/PlaylistOrderService.cs
+++ b/Services/PlaylistOrderService.cs
@@ -1,0 +1,384 @@
+using ApolloSync.Models;
+using Newtonsoft.Json.Linq;
+using Playnite.SDK;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+
+namespace ApolloSync.Services
+{
+    /// <summary>
+    /// Reorders apps.json entries to match Playlist order when the Playlist filter preset
+    /// is included for sync and the Playlist plugin is loaded.
+    /// </summary>
+    internal static class PlaylistOrderService
+    {
+        private static readonly ILogger logger = LogManager.GetLogger();
+
+        internal static readonly Guid PlaylistPluginId = Guid.Parse("b0313f81-2b86-4eba-9f24-1a727dedbd45");
+        internal const string PlaylistPresetName = "Playlist";
+        internal const string PlaylistFileName = "playlist.txt";
+
+        private const int RetrySleepMs = 150;
+        private const int MaxNonEmptyContentRetries = 2;
+
+        public static bool IsPluginLoaded(IPlayniteAPI api)
+        {
+            if (api?.Addons?.Plugins == null)
+            {
+                return false;
+            }
+
+            return api.Addons.Plugins.Any(p => p.Id == PlaylistPluginId);
+        }
+
+        /// <summary>
+        /// True if any included preset id maps to the name "Playlist" (Ordinal).
+        /// <paramref name="getPresetName"/> returns null for missing presets.
+        /// </summary>
+        public static bool IsPlaylistPresetIncluded(IEnumerable<Guid> includedIds, Func<Guid, string> getPresetName)
+        {
+            if (includedIds == null || getPresetName == null)
+            {
+                return false;
+            }
+
+            foreach (var id in includedIds)
+            {
+                var name = getPresetName(id);
+                if (string.Equals(name, PlaylistPresetName, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Parses playlist.txt lines into ordered game ids. Trims, skips invalid, de-dupes (first wins).
+        /// </summary>
+        public static List<Guid> ParsePlaylistLines(IEnumerable<string> lines)
+        {
+            var result = new List<Guid>();
+            if (lines == null)
+            {
+                return result;
+            }
+
+            var seen = new HashSet<Guid>();
+            foreach (var line in lines)
+            {
+                if (string.IsNullOrWhiteSpace(line))
+                {
+                    continue;
+                }
+
+                Guid id;
+                if (!Guid.TryParse(line.Trim(), out id))
+                {
+                    continue;
+                }
+
+                if (seen.Add(id))
+                {
+                    result.Add(id);
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Reads playlist.txt with FileShare.ReadWrite and short retries for truncate/torn races.
+        /// </summary>
+        public static List<Guid> TryReadOrderedGameIds(string playlistTxtPath)
+        {
+            if (string.IsNullOrWhiteSpace(playlistTxtPath) || !File.Exists(playlistTxtPath))
+            {
+                return new List<Guid>();
+            }
+
+            try
+            {
+                var content = ReadFileTextShared(playlistTxtPath);
+                var parsed = ParsePlaylistLines(SplitLines(content));
+
+                if (parsed.Count > 0)
+                {
+                    return parsed;
+                }
+
+                // Empty or unparseable — retry for truncate / torn write races.
+                if (content.Length == 0)
+                {
+                    Thread.Sleep(RetrySleepMs);
+                    content = ReadFileTextShared(playlistTxtPath);
+                    return ParsePlaylistLines(SplitLines(content));
+                }
+
+                for (var attempt = 0; attempt < MaxNonEmptyContentRetries; attempt++)
+                {
+                    Thread.Sleep(RetrySleepMs);
+                    content = ReadFileTextShared(playlistTxtPath);
+                    parsed = ParsePlaylistLines(SplitLines(content));
+                    if (parsed.Count > 0)
+                    {
+                        return parsed;
+                    }
+                }
+
+                return parsed;
+            }
+            catch (IOException ex)
+            {
+                logger.Warn(ex, $"PlaylistOrderService: failed to read playlist file '{playlistTxtPath}'");
+                return new List<Guid>();
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                logger.Warn(ex, $"PlaylistOrderService: access denied reading playlist file '{playlistTxtPath}'");
+                return new List<Guid>();
+            }
+        }
+
+        /// <summary>
+        /// Reorders <paramref name="apps"/>: unmanaged, pinned∩playlist, pinned\playlist,
+        /// non-pinned playlist, other managed. Returns whether the order changed.
+        /// </summary>
+        public static bool ReorderApps(
+            JArray apps,
+            IList<Guid> playlistGameIds,
+            ManagedStore store,
+            ICollection<Guid> pinnedGameIds)
+        {
+            if (apps == null || store == null || store.GameToUuid == null)
+            {
+                return false;
+            }
+
+            var playlistIds = playlistGameIds ?? (IList<Guid>)new List<Guid>();
+            var pinnedIds = pinnedGameIds ?? (ICollection<Guid>)new List<Guid>();
+
+            var managedUuidSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var uuid in store.GameToUuid.Values)
+            {
+                managedUuidSet.Add(ToApolloUuid(uuid));
+            }
+
+            var pinnedUuidSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var pinnedId in pinnedIds)
+            {
+                Guid apolloUuid;
+                if (store.GameToUuid.TryGetValue(pinnedId, out apolloUuid))
+                {
+                    pinnedUuidSet.Add(ToApolloUuid(apolloUuid));
+                }
+            }
+
+            var orderedPlaylistUuids = new List<string>();
+            var playlistUuidSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var gameId in playlistIds)
+            {
+                Guid apolloUuid;
+                if (!store.GameToUuid.TryGetValue(gameId, out apolloUuid))
+                {
+                    continue;
+                }
+
+                var uuidStr = ToApolloUuid(apolloUuid);
+                if (playlistUuidSet.Add(uuidStr))
+                {
+                    orderedPlaylistUuids.Add(uuidStr);
+                }
+            }
+
+            var unmanaged = new List<JToken>();
+            var uuidToToken = new Dictionary<string, JToken>(StringComparer.OrdinalIgnoreCase);
+            var pinnedOnPlaylist = new List<string>();
+            var pinnedNotOnPlaylist = new List<string>();
+            var remaining = new List<string>();
+
+            foreach (var token in apps)
+            {
+                var obj = token as JObject;
+                if (obj == null)
+                {
+                    unmanaged.Add(token);
+                    continue;
+                }
+
+                var uuidStr = ((string)obj["uuid"])?.Trim();
+                if (string.IsNullOrEmpty(uuidStr) || !managedUuidSet.Contains(uuidStr))
+                {
+                    unmanaged.Add(token);
+                    continue;
+                }
+
+                uuidStr = uuidStr.ToUpperInvariant();
+                if (uuidToToken.ContainsKey(uuidStr))
+                {
+                    // Assume unique after Load; first occurrence wins.
+                    continue;
+                }
+
+                uuidToToken[uuidStr] = token;
+
+                if (pinnedUuidSet.Contains(uuidStr))
+                {
+                    if (playlistUuidSet.Contains(uuidStr))
+                    {
+                        pinnedOnPlaylist.Add(uuidStr);
+                    }
+                    else
+                    {
+                        pinnedNotOnPlaylist.Add(uuidStr);
+                    }
+                }
+                else
+                {
+                    remaining.Add(uuidStr);
+                }
+            }
+
+            var pinnedOnPlaylistSet = new HashSet<string>(pinnedOnPlaylist, StringComparer.OrdinalIgnoreCase);
+            var remainingSet = new HashSet<string>(remaining, StringComparer.OrdinalIgnoreCase);
+            var consumed = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var newOrder = new List<JToken>(apps.Count);
+
+            foreach (var token in unmanaged)
+            {
+                newOrder.Add(token);
+            }
+
+            // Pinned ∩ playlist (playlist.txt order)
+            foreach (var uuidStr in orderedPlaylistUuids)
+            {
+                if (!pinnedOnPlaylistSet.Contains(uuidStr) || consumed.Contains(uuidStr))
+                {
+                    continue;
+                }
+
+                JToken token;
+                if (uuidToToken.TryGetValue(uuidStr, out token))
+                {
+                    newOrder.Add(token);
+                    consumed.Add(uuidStr);
+                }
+            }
+
+            // Pinned \ playlist (relative order)
+            foreach (var uuidStr in pinnedNotOnPlaylist)
+            {
+                JToken token;
+                if (uuidToToken.TryGetValue(uuidStr, out token))
+                {
+                    newOrder.Add(token);
+                    consumed.Add(uuidStr);
+                }
+            }
+
+            // Non-pinned ∩ playlist (playlist.txt order)
+            foreach (var uuidStr in orderedPlaylistUuids)
+            {
+                if (!remainingSet.Contains(uuidStr) || consumed.Contains(uuidStr))
+                {
+                    continue;
+                }
+
+                JToken token;
+                if (uuidToToken.TryGetValue(uuidStr, out token))
+                {
+                    newOrder.Add(token);
+                    consumed.Add(uuidStr);
+                }
+            }
+
+            // Other managed (relative order)
+            foreach (var uuidStr in remaining)
+            {
+                if (consumed.Contains(uuidStr))
+                {
+                    continue;
+                }
+
+                JToken token;
+                if (uuidToToken.TryGetValue(uuidStr, out token))
+                {
+                    newOrder.Add(token);
+                    consumed.Add(uuidStr);
+                }
+            }
+
+            if (newOrder.Count == apps.Count)
+            {
+                var unchanged = true;
+                for (var i = 0; i < apps.Count; i++)
+                {
+                    if (!ReferenceEquals(apps[i], newOrder[i]))
+                    {
+                        unchanged = false;
+                        break;
+                    }
+                }
+
+                if (unchanged)
+                {
+                    return false;
+                }
+            }
+
+            apps.Clear();
+            foreach (var token in newOrder)
+            {
+                apps.Add(token);
+            }
+
+            return true;
+        }
+
+        public static string GetPlaylistFilePath(IPlayniteAPI api)
+        {
+            if (api?.Paths?.ExtensionsDataPath == null)
+            {
+                return null;
+            }
+
+            return Path.Combine(api.Paths.ExtensionsDataPath, PlaylistPluginId.ToString(), PlaylistFileName);
+        }
+
+        private static string ToApolloUuid(Guid uuid)
+        {
+            return uuid.ToString().ToUpperInvariant();
+        }
+
+        private static string ReadFileTextShared(string path)
+        {
+            using (var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            using (var reader = new StreamReader(fs, Encoding.UTF8))
+            {
+                return reader.ReadToEnd();
+            }
+        }
+
+        private static IEnumerable<string> SplitLines(string content)
+        {
+            if (content == null)
+            {
+                yield break;
+            }
+
+            using (var reader = new StringReader(content))
+            {
+                string line;
+                while ((line = reader.ReadLine()) != null)
+                {
+                    yield return line;
+                }
+            }
+        }
+    }
+}

--- a/Tests/PlaylistOrderTests.cs
+++ b/Tests/PlaylistOrderTests.cs
@@ -1,0 +1,332 @@
+using ApolloSync.Models;
+using ApolloSync.Services;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace ApolloSync.Tests
+{
+    [TestClass]
+    public class PlaylistOrderTests
+    {
+        private static string ToUuid(Guid id)
+        {
+            return id.ToString().ToUpperInvariant();
+        }
+
+        private static JObject App(string name, Guid uuid)
+        {
+            return new JObject
+            {
+                ["name"] = name,
+                ["uuid"] = ToUuid(uuid),
+                ["id"] = "1"
+            };
+        }
+
+        private static List<string> Names(JArray apps)
+        {
+            return apps.OfType<JObject>().Select(a => (string)a["name"]).ToList();
+        }
+
+        private static ManagedStore Store(params Guid[] gameIds)
+        {
+            var store = new ManagedStore();
+            foreach (var id in gameIds)
+            {
+                store.GameToUuid[id] = id;
+            }
+            return store;
+        }
+
+        [TestMethod]
+        public void IsPlaylistPresetIncluded_MatchesOrdinalPlaylistName()
+        {
+            var playlistId = Guid.NewGuid();
+            var otherId = Guid.NewGuid();
+            Assert.IsTrue(PlaylistOrderService.IsPlaylistPresetIncluded(
+                new[] { otherId, playlistId },
+                id => id == playlistId ? "Playlist" : "Favorites"));
+        }
+
+        [TestMethod]
+        public void IsPlaylistPresetIncluded_FalseWhenMissingOrWrongName()
+        {
+            var id = Guid.NewGuid();
+            Assert.IsFalse(PlaylistOrderService.IsPlaylistPresetIncluded(
+                new[] { id },
+                _ => "Favorites"));
+            Assert.IsFalse(PlaylistOrderService.IsPlaylistPresetIncluded(
+                new[] { id },
+                _ => null));
+            Assert.IsFalse(PlaylistOrderService.IsPlaylistPresetIncluded(
+                null,
+                _ => "Playlist"));
+            Assert.IsFalse(PlaylistOrderService.IsPlaylistPresetIncluded(
+                new Guid[0],
+                _ => "Playlist"));
+        }
+
+        [TestMethod]
+        public void IsPlaylistPresetIncluded_DoesNotMatchLocalizedOrWrongCase()
+        {
+            var id = Guid.NewGuid();
+            Assert.IsFalse(PlaylistOrderService.IsPlaylistPresetIncluded(
+                new[] { id },
+                _ => "playlist"));
+            Assert.IsFalse(PlaylistOrderService.IsPlaylistPresetIncluded(
+                new[] { id },
+                _ => "Liste de lecture"));
+        }
+
+        [TestMethod]
+        public void ParsePlaylistLines_TrimsDedupesAndSkipsInvalid()
+        {
+            var a = Guid.NewGuid();
+            var b = Guid.NewGuid();
+            var lines = new[]
+            {
+                "  " + a.ToString().ToLowerInvariant() + "  ",
+                "not-a-guid",
+                "",
+                a.ToString(),
+                b.ToString().ToUpperInvariant(),
+                null
+            };
+
+            var parsed = PlaylistOrderService.ParsePlaylistLines(lines);
+            CollectionAssert.AreEqual(new[] { a, b }, parsed);
+        }
+
+        [TestMethod]
+        public void TryReadOrderedGameIds_MissingFileReturnsEmpty()
+        {
+            var path = Path.Combine(Path.GetTempPath(), "ApolloSyncTests", Guid.NewGuid().ToString("N"), "missing.txt");
+            var result = PlaylistOrderService.TryReadOrderedGameIds(path);
+            Assert.AreEqual(0, result.Count);
+        }
+
+        [TestMethod]
+        public void TryReadOrderedGameIds_ReadsSharedFile()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "ApolloSyncTests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            var path = Path.Combine(dir, "playlist.txt");
+            try
+            {
+                var a = Guid.NewGuid();
+                var b = Guid.NewGuid();
+                File.WriteAllLines(path, new[] { a.ToString(), b.ToString() });
+
+                var result = PlaylistOrderService.TryReadOrderedGameIds(path);
+                CollectionAssert.AreEqual(new[] { a, b }, result);
+            }
+            finally
+            {
+                if (Directory.Exists(dir))
+                {
+                    Directory.Delete(dir, true);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void ReorderApps_UnmanagedFirst_ThenPinnedHybrid_ThenPlaylist_ThenOther()
+        {
+            var desktop = Guid.NewGuid();
+            var pinnedPlaylistA = Guid.NewGuid();
+            var pinnedPlaylistB = Guid.NewGuid();
+            var pinnedOther = Guid.NewGuid();
+            var playlistOnly = Guid.NewGuid();
+            var otherManaged = Guid.NewGuid();
+
+            // Shuffled managed order in apps; playlist order is B then A then playlistOnly
+            var apps = new JArray
+            {
+                App("OtherManaged", otherManaged),
+                App("Desktop", desktop), // unmanaged — not in store
+                App("PinnedPlaylistA", pinnedPlaylistA),
+                App("PlaylistOnly", playlistOnly),
+                App("PinnedOther", pinnedOther),
+                App("PinnedPlaylistB", pinnedPlaylistB),
+            };
+
+            var store = Store(pinnedPlaylistA, pinnedPlaylistB, pinnedOther, playlistOnly, otherManaged);
+            var playlist = new List<Guid> { pinnedPlaylistB, pinnedPlaylistA, playlistOnly };
+            var pinned = new HashSet<Guid> { pinnedPlaylistA, pinnedPlaylistB, pinnedOther };
+
+            Assert.IsTrue(PlaylistOrderService.ReorderApps(apps, playlist, store, pinned));
+
+            CollectionAssert.AreEqual(
+                new[]
+                {
+                    "Desktop",
+                    "PinnedPlaylistB",
+                    "PinnedPlaylistA",
+                    "PinnedOther",
+                    "PlaylistOnly",
+                    "OtherManaged"
+                },
+                Names(apps));
+        }
+
+        [TestMethod]
+        public void ReorderApps_PinnedAndOnPlaylistAppearsOnlyInPinnedPlaylistBucket()
+        {
+            var both = Guid.NewGuid();
+            var apps = new JArray
+            {
+                App("Both", both),
+            };
+            var store = Store(both);
+            var playlist = new List<Guid> { both };
+            var pinned = new HashSet<Guid> { both };
+
+            Assert.IsFalse(PlaylistOrderService.ReorderApps(apps, playlist, store, pinned));
+            Assert.AreEqual(1, apps.Count);
+            Assert.AreEqual("Both", (string)apps[0]["name"]);
+        }
+
+        [TestMethod]
+        public void ReorderApps_EmptyPlaylist_PinnedThenOther_RelativeOrder()
+        {
+            var pinned1 = Guid.NewGuid();
+            var pinned2 = Guid.NewGuid();
+            var other = Guid.NewGuid();
+            var desktop = Guid.NewGuid();
+
+            var apps = new JArray
+            {
+                App("Other", other),
+                App("Pinned2", pinned2),
+                App("Desktop", desktop),
+                App("Pinned1", pinned1),
+            };
+
+            var store = Store(pinned1, pinned2, other);
+            var changed = PlaylistOrderService.ReorderApps(apps, new List<Guid>(), store, new HashSet<Guid> { pinned1, pinned2 });
+            Assert.IsTrue(changed);
+
+            CollectionAssert.AreEqual(
+                new[] { "Desktop", "Pinned2", "Pinned1", "Other" },
+                Names(apps));
+        }
+
+        [TestMethod]
+        public void ReorderApps_EmptyPlaylistNoPins_UnmanagedThenAllManagedRelative()
+        {
+            var a = Guid.NewGuid();
+            var b = Guid.NewGuid();
+            var desktop = Guid.NewGuid();
+
+            var apps = new JArray
+            {
+                App("A", a),
+                App("Desktop", desktop),
+                App("B", b),
+            };
+
+            var store = Store(a, b);
+            Assert.IsTrue(PlaylistOrderService.ReorderApps(apps, new List<Guid>(), store, new HashSet<Guid>()));
+
+            CollectionAssert.AreEqual(new[] { "Desktop", "A", "B" }, Names(apps));
+        }
+
+        [TestMethod]
+        public void ReorderApps_LowercasePlaylistGuidsMatchUppercaseAppsUuids()
+        {
+            var gameId = Guid.NewGuid();
+            var apps = new JArray
+            {
+                App("Other", Guid.NewGuid()),
+                App("Game", gameId),
+            };
+            // Put other managed first so reorder must move Game
+            var other = Guid.Parse((string)apps[0]["uuid"]);
+            var store = Store(other, gameId);
+
+            // playlist list uses the Guid value (same as game id); Reorder compares via store + uppercase
+            Assert.IsTrue(PlaylistOrderService.ReorderApps(
+                apps,
+                new List<Guid> { gameId },
+                store,
+                new HashSet<Guid>()));
+
+            Assert.AreEqual("Game", (string)apps[0]["name"]);
+            Assert.AreEqual("Other", (string)apps[1]["name"]);
+        }
+
+        [TestMethod]
+        public void ReorderApps_NonIdentityStoreMapping()
+        {
+            var gameId = Guid.NewGuid();
+            var apolloUuid = Guid.NewGuid();
+            var apps = new JArray
+            {
+                App("Other", Guid.NewGuid()),
+                App("Mapped", apolloUuid),
+            };
+            var other = Guid.Parse((string)apps[0]["uuid"]);
+
+            var store = new ManagedStore();
+            store.GameToUuid[other] = other;
+            store.GameToUuid[gameId] = apolloUuid;
+
+            Assert.IsTrue(PlaylistOrderService.ReorderApps(
+                apps,
+                new List<Guid> { gameId },
+                store,
+                new HashSet<Guid>()));
+
+            Assert.AreEqual("Mapped", (string)apps[0]["name"]);
+            Assert.AreEqual("Other", (string)apps[1]["name"]);
+        }
+
+        [TestMethod]
+        public void ReorderApps_NullAppsReturnsFalse()
+        {
+            Assert.IsFalse(PlaylistOrderService.ReorderApps(
+                null,
+                new List<Guid>(),
+                new ManagedStore(),
+                new HashSet<Guid>()));
+        }
+
+        [TestMethod]
+        public void ReorderApps_NullPlaylistAndPinnedTreatedAsEmpty()
+        {
+            var managed = Guid.NewGuid();
+            var desktop = Guid.NewGuid();
+            var apps = new JArray
+            {
+                App("Managed", managed),
+                App("Desktop", desktop),
+            };
+            var store = Store(managed);
+
+            Assert.IsTrue(PlaylistOrderService.ReorderApps(apps, null, store, null));
+            CollectionAssert.AreEqual(new[] { "Desktop", "Managed" }, Names(apps));
+        }
+
+        [TestMethod]
+        public void ReorderApps_UnchangedOrderReturnsFalse()
+        {
+            var a = Guid.NewGuid();
+            var b = Guid.NewGuid();
+            var apps = new JArray
+            {
+                App("Desktop", Guid.NewGuid()),
+                App("A", a),
+                App("B", b),
+            };
+            // Desktop not in store
+            var store = Store(a, b);
+            var playlist = new List<Guid> { a, b };
+
+            Assert.IsFalse(PlaylistOrderService.ReorderApps(apps, playlist, store, new HashSet<Guid>()));
+        }
+    }
+}


### PR DESCRIPTION
This PR adds sort-order integration with the Playlist plugin (either the [original ](https://github.com/bburky/playnite-playlist)or my [fork ](https://github.com/kinland/playnite-playlist-reborn/). When bburky has time to finish their review of https://github.com/bburky/playnite-playlist/pull/17 , there will only be one Playlist plugin, which is why I'm not handling two different Playlist plugins)

My fork of the Playlist plugin generates an eponymous filter preset based on the user's `Playlist`, which integrates nicely into ApolloSync. However, since presets have no notion of sorting by numeric rank, you end up with games in fairly arbitrary orders. Fine when you have a short playlist, but mine is sitting at around 250 games.

Thankfully, the orders are obtainable by parsing the Playlist plugin's data.

This PR adds an integration surface: when the `Playlist` preset is included in `Filter Presets` and the plugin itself is actually loaded (in case someone makes an unrelated Playlist preset), reorder managed Apollo entries on save: pinned∩playlist, other pins, non-pinned playlist, then the rest—so Moonlight clients follow playlist rank without needing Playlist.dll reference.

With this change, games that a player has indicated are high on their priority list will naturally end up near the top of the apps.json list.

Also added related tests.