### PR TITLE
Make the pinned-vs-excluded test exercise the exclude path

### DIFF
--- a/Tests/AppsJsonManagementTests.cs
+++ b/Tests/AppsJsonManagementTests.cs
@@ -490,8 +490,37 @@ namespace ApolloSync.Tests
         [TestMethod]
         public void EvaluateExportEligibility_PinnedGameThatMatchesExcludeIsKept()
         {
+            // Pinning protects a game from removal but never forces it into the export set, so a
+            // pinned game that matches an exclude must come back ineligible AND still be kept.
+            // Written this way deliberately: asserting ShouldRemoveManagedGame with a hardcoded
+            // meetsFilters:false would duplicate ShouldRemoveManagedGame_KeepsPinnedGameThat-
+            // NoLongerMatches and would pass with the exclude feature reverted entirely.
+            var included = Guid.NewGuid();
+            var excluded = Guid.NewGuid();
+
+            bool failed;
+            var eligible = global::ApolloSync.ApolloSync.EvaluateExportEligibility(
+                new List<Guid> { included },
+                new List<Guid> { excluded },
+                id => id == included || id == excluded,
+                out failed);
+
+            Assert.IsFalse(eligible, "an excluded game is never eligible, even when also included");
+            Assert.IsFalse(failed, "a definite exclusion is not an evaluation failure");
+
             Assert.IsFalse(global::ApolloSync.ApolloSync.ShouldRemoveManagedGame(
-                gameExistsInLibrary: true, isPinned: true, meetsFilters: false, filterEvaluationFailed: false));
+                gameExistsInLibrary: true,
+                isPinned: true,
+                meetsFilters: eligible,
+                filterEvaluationFailed: failed));
+
+            // And the same game unpinned is removed — otherwise the assertion above would hold
+            // for reasons unrelated to pinning.
+            Assert.IsTrue(global::ApolloSync.ApolloSync.ShouldRemoveManagedGame(
+                gameExistsInLibrary: true,
+                isPinned: false,
+                meetsFilters: eligible,
+                filterEvaluationFailed: failed));
         }
 
         // ── ApplyRemovals ─────────────────────────────────────────────────────────


### PR DESCRIPTION
Follow-up to #33, addressing the one item flagged in review there.

`EvaluateExportEligibility_PinnedGameThatMatchesExcludeIsKept` never called `EvaluateExportEligibility`. It asserted `ShouldRemoveManagedGame` with a hardcoded `meetsFilters: false`, which duplicates the pre-existing `ShouldRemoveManagedGame_KeepsPinnedGameThatNoLongerMatches` verbatim — so it would pass with the exclude-preset feature reverted entirely, and never guarded the pin/exclude interaction its name promises.

It now runs a game matching **both** an include and an exclude through `EvaluateExportEligibility`, then feeds the real verdict into `ShouldRemoveManagedGame`: a pinned game survives, and the same game unpinned is removed. The second half matters — without it the first assertion would hold for reasons unrelated to pinning.

That also covers something nothing tested before: that pinning protects against removal without forcing an excluded game back into the export set.

**Verification** — 92/92 pass, and mutation-checked:

| Mutation | Before | After |
|---|---|---|
| `if (excluded)` → `if (false)` (exclusion no longer wins) | survived | **killed** (3 tests) |
| definite exclusion sets `evaluationFailed = true` | survived | **killed** (5 tests) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)